### PR TITLE
Apt - Minimum Viable Buildpack - 04 - Install Packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,10 +72,14 @@ name = "buildpacks-apt"
 version = "0.0.0"
 dependencies = [
  "commons",
+ "fun_run",
  "indoc",
  "libcnb 0.19.0",
  "libcnb-test",
+ "regex-lite",
+ "semver",
  "serde",
+ "tempfile",
  "toml",
 ]
 
@@ -623,6 +627,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b661b2f27137bdbc16f00eda72866a92bb28af1753ffbd56744fb6e2e9cd8e"
 
 [[package]]
 name = "regex-syntax"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,13 +5,18 @@ rust-version = "1.76"
 
 [dependencies]
 commons = { git = "https://github.com/heroku/buildpacks-ruby", branch = "main" }
+fun_run = "0.1"
 libcnb = "=0.19.0"
+indoc = "2"
+semver = "1"
 serde = "1"
+tempfile = "3"
 
 [dev-dependencies]
 libcnb-test = "=0.19.0"
 indoc = "2"
 toml = "0.8"
+regex-lite = "0.1"
 
 [lints.rust]
 unreachable_pub = "warn"

--- a/src/aptfile.rs
+++ b/src/aptfile.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct Aptfile {
-    packages: HashSet<DebianPackageName>,
+    pub(crate) packages: HashSet<DebianPackageName>,
 }
 
 impl FromStr for Aptfile {

--- a/src/commands/apt_get.rs
+++ b/src/commands/apt_get.rs
@@ -1,0 +1,282 @@
+use crate::debian::DebianPackageName;
+use std::collections::HashSet;
+use std::ops::Deref;
+use std::path::PathBuf;
+use std::process::Command;
+use std::str::FromStr;
+
+// https://manpages.ubuntu.com/manpages/jammy/en/man8/apt-get.8.html
+
+#[derive(Debug, Default, Clone)]
+#[allow(clippy::struct_excessive_bools)]
+pub(crate) struct AptGetCommand {
+    pub(crate) allow_downgrades: bool,
+    pub(crate) allow_remove_essential: bool,
+    pub(crate) allow_change_held_packages: bool,
+    pub(crate) assume_yes: bool,
+    pub(crate) config_file: Option<PathBuf>,
+    pub(crate) download_only: bool,
+    pub(crate) force_yes: bool,
+    pub(crate) reinstall: bool,
+    pub(crate) version: bool,
+}
+
+impl AptGetCommand {
+    pub(crate) fn new() -> Self {
+        AptGetCommand::default()
+    }
+
+    pub(crate) fn install(&self) -> AptGetInstallCommand {
+        AptGetInstallCommand::new(self.clone())
+    }
+
+    pub(crate) fn update(&self) -> AptGetUpdateCommand {
+        AptGetUpdateCommand::new(self.clone())
+    }
+}
+
+impl From<AptGetCommand> for Command {
+    fn from(value: AptGetCommand) -> Self {
+        let mut command = Command::new("apt-get");
+
+        if value.allow_downgrades {
+            command.arg("--allow-downgrades");
+        }
+        if value.allow_remove_essential {
+            command.arg("--allow-remove-essential");
+        }
+        if value.allow_change_held_packages {
+            command.arg("--allow-change-held-packages");
+        }
+        if value.assume_yes {
+            command.arg("--assume-yes");
+        }
+        if let Some(config_file) = value.config_file {
+            command.arg("--config-file");
+            command.arg(config_file);
+        }
+        if value.download_only {
+            command.arg("--download-only");
+        }
+        if value.force_yes {
+            command.arg("--force-yes");
+        }
+        if value.reinstall {
+            command.arg("--reinstall");
+        }
+        if value.version {
+            command.arg("--version");
+        }
+        command
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct AptGetInstallCommand {
+    apt_get_command: AptGetCommand,
+    pub(crate) packages: HashSet<DebianPackageName>,
+}
+
+impl AptGetInstallCommand {
+    fn new(apt_get_command: AptGetCommand) -> Self {
+        Self {
+            apt_get_command,
+            packages: HashSet::new(),
+        }
+    }
+}
+
+impl From<AptGetInstallCommand> for Command {
+    fn from(value: AptGetInstallCommand) -> Self {
+        let mut command: Command = value.apt_get_command.into();
+        command.arg("install");
+        command.args(value.packages);
+        command
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct AptGetUpdateCommand {
+    apt_get_command: AptGetCommand,
+}
+
+impl AptGetUpdateCommand {
+    fn new(apt_get_command: AptGetCommand) -> Self {
+        Self { apt_get_command }
+    }
+}
+
+impl From<AptGetUpdateCommand> for Command {
+    fn from(value: AptGetUpdateCommand) -> Self {
+        let mut command: Command = value.apt_get_command.into();
+        command.arg("update");
+        command
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct AptVersion(semver::Version);
+
+#[derive(Debug)]
+#[allow(dead_code)] // TODO: remove after error messages are added
+pub(crate) enum ParseAptVersionError {
+    UnexpectedOutput(String),
+    InvalidVersion(String, semver::Error),
+}
+
+impl FromStr for AptVersion {
+    type Err = ParseAptVersionError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let first_line = value
+            .lines()
+            .next()
+            .ok_or(ParseAptVersionError::UnexpectedOutput(value.to_string()))?;
+
+        let mut tokens = first_line.split(' ');
+        if let Some("apt") = tokens.next() {
+            tokens
+                .next()
+                .ok_or(ParseAptVersionError::UnexpectedOutput(value.to_string()))
+                .and_then(|version_string| {
+                    semver::Version::parse(version_string)
+                        .map(AptVersion)
+                        .map_err(|e| {
+                            ParseAptVersionError::InvalidVersion(version_string.to_string(), e)
+                        })
+                })
+        } else {
+            Err(ParseAptVersionError::UnexpectedOutput(value.to_string()))
+        }
+    }
+}
+
+impl Deref for AptVersion {
+    type Target = semver::Version;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indoc::indoc;
+
+    #[test]
+    fn test_apt_get_version() {
+        let mut apt_get = AptGetCommand::new();
+        apt_get.version = true;
+        let command: Command = apt_get.into();
+        assert_eq!(command.get_program(), "apt-get");
+        assert_eq!(command.get_args().collect::<Vec<_>>(), &["--version"]);
+    }
+
+    #[test]
+    fn test_apt_get_update() {
+        let apt_get_update = AptGetCommand::new().update();
+        let command: Command = apt_get_update.into();
+        assert_eq!(command.get_program(), "apt-get");
+        assert_eq!(command.get_args().collect::<Vec<_>>(), &["update"]);
+    }
+
+    #[test]
+    fn test_apt_get_install_with_force_yes() {
+        let mut apt_get = AptGetCommand::new();
+        apt_get.assume_yes = true;
+        apt_get.download_only = true;
+        apt_get.reinstall = true;
+        apt_get.force_yes = true;
+        let mut apt_get_install = apt_get.install();
+        apt_get_install
+            .packages
+            .insert(DebianPackageName::from_str("some-package").unwrap());
+        let command: Command = apt_get_install.into();
+        assert_eq!(command.get_program(), "apt-get");
+        assert_eq!(
+            command.get_args().collect::<Vec<_>>(),
+            &[
+                "--assume-yes",
+                "--download-only",
+                "--force-yes",
+                "--reinstall",
+                "install",
+                "some-package"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_apt_get_install_without_force_yes() {
+        let mut apt_get = AptGetCommand::new();
+        apt_get.assume_yes = true;
+        apt_get.download_only = true;
+        apt_get.reinstall = true;
+        apt_get.allow_downgrades = true;
+        apt_get.allow_remove_essential = true;
+        apt_get.allow_change_held_packages = true;
+        let mut apt_get_install = apt_get.install();
+        apt_get_install
+            .packages
+            .insert(DebianPackageName::from_str("some-package").unwrap());
+        let command: Command = apt_get_install.into();
+        assert_eq!(command.get_program(), "apt-get");
+        assert_eq!(
+            command.get_args().collect::<Vec<_>>(),
+            &[
+                "--allow-downgrades",
+                "--allow-remove-essential",
+                "--allow-change-held-packages",
+                "--assume-yes",
+                "--download-only",
+                "--reinstall",
+                "install",
+                "some-package"
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_apt_version() {
+        let apt_version = AptVersion::from_str(indoc! { "
+            apt 2.4.11 (amd64)
+            Supported modules:
+            *Ver: Standard .deb
+             Pkg:  Debian APT solver interface (Priority -1000)
+             Pkg:  Debian APT planner interface (Priority -1000)
+            *Pkg:  Debian dpkg interface (Priority 30)
+             S.L: 'deb' Debian binary tree
+             S.L: 'deb-src' Debian source tree
+             Idx: EDSP scenario file
+             Idx: EIPP scenario file
+             Idx: Debian Source Index
+             Idx: Debian Package Index
+             Idx: Debian Translation Index
+             Idx: Debian dpkg status file
+             Idx: Debian deb file
+             Idx: Debian dsc file
+             Idx: Debian control file            
+        " })
+        .unwrap();
+        assert_eq!(*apt_version, semver::Version::new(2, 4, 11));
+    }
+
+    #[test]
+    fn parse_apt_version_with_unexpected_output() {
+        let error = AptVersion::from_str("badoutput").unwrap_err();
+        match error {
+            ParseAptVersionError::UnexpectedOutput(output) => assert_eq!(&output, "badoutput"),
+            ParseAptVersionError::InvalidVersion(_, _) => panic!("wrong error type"),
+        };
+    }
+
+    #[test]
+    fn parse_apt_version_with_invalid_semver() {
+        let error = AptVersion::from_str("apt 1.2").unwrap_err();
+        match error {
+            ParseAptVersionError::UnexpectedOutput(_) => panic!("wrong error type"),
+            ParseAptVersionError::InvalidVersion(version, _) => assert_eq!(&version, "1.2"),
+        };
+    }
+}

--- a/src/commands/dpkg.rs
+++ b/src/commands/dpkg.rs
@@ -1,0 +1,51 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+// https://manpages.ubuntu.com/manpages/jammy/en/man1/dpkg.1.html
+// https://manpages.ubuntu.com/manpages/jammy/en/man1/dpkg-deb.1.html
+#[derive(Debug, Default, Clone)]
+pub(crate) struct DpkgCommand {
+    extract_action: Option<(PathBuf, PathBuf)>,
+}
+
+impl DpkgCommand {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn extract(&mut self, archive: PathBuf, target_directory: PathBuf) {
+        self.extract_action = Some((archive, target_directory));
+    }
+}
+
+impl From<DpkgCommand> for Command {
+    fn from(value: DpkgCommand) -> Self {
+        let mut command = Command::new("dpkg");
+        if let Some((archive, target_directory)) = value.extract_action {
+            command.arg("--extract");
+            command.arg(archive);
+            command.arg(target_directory);
+        }
+        command
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_dpkg_extract() {
+        let mut dpkg = DpkgCommand::new();
+        dpkg.extract(
+            PathBuf::from("some-archive.deb"),
+            PathBuf::from("target-directory"),
+        );
+        let command: Command = dpkg.into();
+        assert_eq!(command.get_program(), "dpkg");
+        assert_eq!(
+            command.get_args().collect::<Vec<_>>(),
+            &["--extract", "some-archive.deb", "target-directory"]
+        );
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod apt_get;
+pub(crate) mod dpkg;

--- a/src/debian.rs
+++ b/src/debian.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::ffi::OsStr;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
@@ -6,6 +7,12 @@ use std::str::FromStr;
 #[serde(deny_unknown_fields)]
 // https://www.debian.org/doc/debian-policy/ch-controlfields.html#source
 pub(crate) struct DebianPackageName(pub(crate) String);
+
+impl AsRef<OsStr> for DebianPackageName {
+    fn as_ref(&self) -> &OsStr {
+        self.0.as_ref()
+    }
+}
 
 impl FromStr for DebianPackageName {
     type Err = ParseDebianPackageNameError;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,7 @@
 use crate::aptfile::ParseAptfileError;
+use crate::commands::apt_get::ParseAptVersionError;
 use crate::debian::ParseDebianArchitectureNameError;
+use std::path::PathBuf;
 
 #[derive(Debug)]
 #[allow(clippy::enum_variant_names)]
@@ -9,6 +11,14 @@ pub(crate) enum AptBuildpackError {
     ReadAptfile(std::io::Error),
     ParseAptfile(ParseAptfileError),
     ParseDebianArchitectureName(ParseDebianArchitectureNameError),
+    CreateAptDir(std::io::Error),
+    CreateAptConfig(std::io::Error),
+    AptGetVersionCommand(fun_run::CmdError),
+    ParseAptGetVersion(ParseAptVersionError),
+    AptGetUpdate(fun_run::CmdError),
+    DownloadPackages(fun_run::CmdError),
+    ListDownloadedPackages(std::io::Error),
+    InstallPackage(PathBuf, fun_run::CmdError),
 }
 
 impl From<AptBuildpackError> for libcnb::Error<AptBuildpackError> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,11 +11,14 @@ use libcnb::generic::{GenericMetadata, GenericPlatform};
 use libcnb::{buildpack_main, Buildpack};
 #[cfg(test)]
 use libcnb_test as _;
+#[cfg(test)]
+use regex_lite as _;
 use std::fs;
 use std::io::stdout;
 use std::str::FromStr;
 
 mod aptfile;
+mod commands;
 mod debian;
 mod errors;
 mod layers;

--- a/tests/macros/mod.rs
+++ b/tests/macros/mod.rs
@@ -1,0 +1,35 @@
+#[macro_export]
+macro_rules! assert_matches {
+    ($left:expr, $right:expr $(,)?) => {{
+        let regex = regex_lite::Regex::new($right).expect("should be a valid regex");
+        if !regex.is_match(&$left) {
+            ::std::panic!(
+                r#"assertion failed: `(left matches right)`
+left (unescaped):
+{}
+left (escaped): `{:?}`
+right: `{:?}`"#,
+                $left,
+                $left,
+                $right,
+            )
+        }
+    }};
+
+    ($left:expr, $right:expr, $($arg:tt)+) => {{
+        let regex = regex_lite::Regex::new($right).expect("should be a valid regex");
+        if !regex.is_match(&$left) {
+            ::std::panic!(
+                r#"assertion failed: `(left matches right)`
+left (unescaped):
+{}
+left (escaped): `{:?}`
+right: `{:?}`: {}"#,
+                $left,
+                $left,
+                $right,
+                ::core::format_args!($($arg)+)
+            )
+        }
+    }};
+}


### PR DESCRIPTION
This PR provides the functionality for downloading Debian packages with `apt-get` and extracting them with `dpkg` into the buildpack layer defined in #7. 

### apt-get

The [`apt-get`](https://manpages.ubuntu.com/manpages/jammy/en/man8/apt-get.8.html) command line application is exposed through the `AptGetCommand` struct which provides fields that map to command line arguments as well as functions that expose sub-commands via `AptGetUpdateCommand` and `AptGetInstallCommand`.  These structs all implement `From<T> for Command` for easy conversion into spawned processes.  This allows for the following commands to be executed:
- `apt-get --version`
- `apt-get update`
- `apt-get --assume-yes --download-only --force-yes --reinstall install some-package` (for apt-get version <= 1.0)
- `apt-get --allow-downgrades --allow-remove-essential --allow-change-held-packages --download-only --reinstall install some-package` (for apt-get version > 1.0)

Since the install process needs to know if it the `--force-yes` flag can be used or the `--allow-downgrades --allow-remove-essential --allow-change-held-packages` flags should be used instead, there is also an `AptVersion` struct and parser provided.  The `AptVersion` wraps a `semver::Version` so that it retains some domain language context but can operate like the underlying type through dereferencing.

### dpkg

Similar to the above `apt-get` setup, the [`dpkg`](https://manpages.ubuntu.com/manpages/jammy/en/man1/dpkg.1.html) command line application is exposed through the `DpkgCommand` struct which exposes the [`dpkg-deb extract`](https://manpages.ubuntu.com/manpages/jammy/en/man1/dpkg-deb.1.html) action.  This struct implements `From<T> for Command` for easy conversion into spawned processes. This allows for the following command to be executed:
- `dpkg --extract some-archive.deb /path/to/target-directory`

---
- ⬆️ #7 
- ⬇️ #9 