### PR TITLE
Update CI to Ubuntu 24.04 runner images

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   check-changelog:
-    runs-on: pub-hk-ubuntu-22.04-small # TODO: change to ubuntu-latest once repo is public
+    runs-on: pub-hk-ubuntu-24.04-ip # TODO: change to ubuntu-24.04 once repo is public
     if: (!contains(github.event.pull_request.labels.*.name, 'skip changelog'))
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   lint:
-    runs-on: pub-hk-ubuntu-22.04-small # TODO: change to ubuntu-latest once repo is public
+    runs-on: pub-hk-ubuntu-24.04-ip # TODO: change to ubuntu-24.04 once repo is public
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,7 +29,7 @@ jobs:
         run: cargo fmt -- --check
 
   unit-test:
-    runs-on: pub-hk-ubuntu-22.04-small # TODO: change to ubuntu-latest once repo is public
+    runs-on: pub-hk-ubuntu-24.04-ip # TODO: change to ubuntu-24.04 once repo is public
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -41,7 +41,7 @@ jobs:
         run: cargo test --locked
 
   integration-test:
-    runs-on: pub-hk-ubuntu-22.04-small # TODO: change to ubuntu-latest once repo is public
+    runs-on: pub-hk-ubuntu-24.04-ip # TODO: change to ubuntu-24.04 once repo is public
     strategy:
       fail-fast: false
       matrix:
@@ -61,7 +61,17 @@ jobs:
         uses: Swatinem/rust-cache@v2.7.3
       - name: Install Pack CLI
         uses: buildpacks/github-actions/setup-pack@v5.6.0
+      # The images are pulled up front to prevent duplicate pulls due to the tests being run concurrently.
       - name: Pull builder image
         run: docker pull ${{ env.INTEGRATION_TEST_CNB_BUILDER }}
+      - name: Pull run image
+        # Using `docker inspect` rather than `pack builder inspect` since the latter makes
+        # additional requests to Docker Hub even when the image is available locally.
+        run: |
+          RUN_IMAGE=$(
+            docker inspect --format='{{index .Config.Labels "io.buildpacks.builder.metadata"}}' '${{ env.INTEGRATION_TEST_CNB_BUILDER }}' \
+              | jq --exit-status --raw-output '.stack.runImage.image'
+          )
+          docker pull "${RUN_IMAGE}"
       - name: Run integration tests
         run: cargo test --locked -- --ignored --test-threads 5


### PR DESCRIPTION
Now that Ubuntu 24.04 images are available on GitHub Actions, we can update from the Ubuntu 22.04 images.

I've also added run image pulling, similar to:
https://github.com/heroku/buildpacks-python/pull/223

See also:
https://github.com/actions/runner-images/issues/9848
https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
https://salesforce.quip.com/bu6UA0KImOxJ#temp:C:GZRd13d2ce2d455470495cbd34cf

GUS-W-16238120.
