### PR TITLE
Fix Clippy error about `pedantic` group priority

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,6 @@ unused_crate_dependencies = "warn"
 
 [lints.clippy]
 panic_in_result_fn = "warn"
-pedantic = "warn"
+# The explicit priority is required due to https://github.com/rust-lang/cargo/issues/13565.
+pedantic = { level = "warn", priority = -1 }
 unwrap_used = "warn"


### PR DESCRIPTION
With newer versions of Rust, Clippy was failing on `main` with:

```
error: lint group `pedantic` has the same priority (0) as a lint
  --> Cargo.toml:23:1
   |
23 | pedantic = "warn"
   | ^^^^^^^^   ------ has an implicit priority of 0
24 | unwrap_used = "warn"
   | ----------- has the same priority as this lint
   |
   = note: the order of the lints in the table is ignored by Cargo
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#lint_groups_priority
   = note: `#[deny(clippy::lint_groups_priority)]` on by default
help: to have lints override the group set `pedantic` to a lower priority
   |
23 | pedantic = { level = "warn", priority = -1 }
   |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

eg:
https://github.com/heroku/buildpacks-apt/actions/runs/9955852891/job/27504486097?pr=32#step:5:188

See also:
https://github.com/heroku/buildpacks-python/pull/184