### PR TITLE
Adds error handling routines and messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,7 @@ dependencies = [
  "sequoia-openpgp",
  "serde",
  "sha2",
+ "strip-ansi-escapes",
  "tempfile",
  "tokio",
  "tokio-tar",
@@ -2789,6 +2790,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ff8ef943b384c414f54aefa961dd2bd853add74ec75e7ac74cf91dba62bcfa"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3182,10 +3192,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vte"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
+dependencies = [
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,9 +287,11 @@ dependencies = [
  "ar",
  "async-compression",
  "bon",
+ "bullet_stream",
  "debversion",
  "futures 0.3.30",
  "indexmap",
+ "indoc",
  "libcnb",
  "libcnb-test",
  "rayon",
@@ -307,6 +309,12 @@ dependencies = [
  "toml_edit",
  "walkdir",
 ]
+
+[[package]]
+name = "bullet_stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec939946cfeb7d4ba709fb24f035a14b78b89641cd4a09434a6d317c0ae28a6"
 
 [[package]]
 name = "bumpalo"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,10 @@ toml_edit = "0.22"
 walkdir = "2"
 
 [dev-dependencies]
-tempfile = "3"
 libcnb-test = "=0.23.0"
 regex = "1"
+strip-ansi-escapes = "0.2"
+tempfile = "3"
 
 [lints.rust]
 unreachable_pub = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,13 @@ anyhow = "1"
 apt-parser = "1"
 ar = "0.9"
 async-compression = { version = "0.4", default-features = false, features = ["tokio", "gzip", "zstd", "xz"] }
+bon = "2"
+bullet_stream = "0.2"
 debversion = "0.4"
 futures = { version = "0.3", default-features = false, features = ["io-compat"] }
 indexmap = "2"
 libcnb = { version = "=0.23.0", features = ["trace"] }
+indoc = "2"
 rayon = "1"
 reqwest = { version = "0.12", default-features = false, features = ["stream", "rustls-tls"] }
 reqwest-middleware = "0.3"
@@ -29,7 +32,6 @@ toml_edit = "0.22"
 walkdir = "2"
 
 [dev-dependencies]
-bon = "2"
 tempfile = "3"
 libcnb-test = "=0.23.0"
 regex = "1"

--- a/src/config/buildpack_config.rs
+++ b/src/config/buildpack_config.rs
@@ -1,34 +1,45 @@
-use indexmap::IndexSet;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
+use indexmap::IndexSet;
 use toml_edit::{DocumentMut, TableLike};
 
-use crate::config::ConfigError::{InvalidToml, ParseRequestedPackage, WrongConfigType};
+use crate::config::ConfigError::{CheckExists, ParseConfig, ReadConfig};
 use crate::config::{ParseRequestedPackageError, RequestedPackage};
-use crate::debian::ParsePackageNameError;
+use crate::{BuildpackResult, DebianPackagesBuildpackError};
 
 #[derive(Debug, Default, Eq, PartialEq)]
 pub(crate) struct BuildpackConfig {
     pub(crate) install: IndexSet<RequestedPackage>,
 }
 
+impl BuildpackConfig {
+    pub(crate) fn exists(config_file: impl AsRef<Path>) -> BuildpackResult<bool> {
+        Ok(config_file
+            .as_ref()
+            .try_exists()
+            .map_err(|e| CheckExists(config_file.as_ref().to_path_buf(), e))?)
+    }
+}
+
 impl TryFrom<PathBuf> for BuildpackConfig {
     type Error = ConfigError;
 
     fn try_from(value: PathBuf) -> Result<Self, Self::Error> {
-        fs::read_to_string(value)
-            .map_err(ConfigError::ReadConfig)
-            .and_then(|contents| BuildpackConfig::from_str(&contents))
+        fs::read_to_string(&value)
+            .map_err(|e| ReadConfig(value.clone(), e))
+            .and_then(|contents| {
+                BuildpackConfig::from_str(&contents).map_err(|e| ParseConfig(value, e))
+            })
     }
 }
 
 impl FromStr for BuildpackConfig {
-    type Err = ConfigError;
+    type Err = ParseConfigError;
 
     fn from_str(contents: &str) -> Result<Self, Self::Err> {
-        let doc = DocumentMut::from_str(contents).map_err(InvalidToml)?;
+        let doc = DocumentMut::from_str(contents).map_err(Self::Err::InvalidToml)?;
 
         // the root config is the table named `[com.heroku.buildpacks.debian-packages]` in project.toml
         let root_config_item = doc
@@ -44,14 +55,14 @@ impl FromStr for BuildpackConfig {
             None => Ok(BuildpackConfig::default()),
             Some(item) => item
                 .as_table_like()
-                .ok_or(WrongConfigType)
+                .ok_or(Self::Err::WrongConfigType)
                 .map(BuildpackConfig::try_from)?,
         }
     }
 }
 
 impl TryFrom<&dyn TableLike> for BuildpackConfig {
-    type Error = ConfigError;
+    type Error = ParseConfigError;
 
     fn try_from(config_item: &dyn TableLike) -> Result<Self, Self::Error> {
         let mut install = IndexSet::new();
@@ -59,7 +70,8 @@ impl TryFrom<&dyn TableLike> for BuildpackConfig {
         if let Some(install_values) = config_item.get("install").and_then(|item| item.as_array()) {
             for install_value in install_values {
                 install.insert(
-                    RequestedPackage::try_from(install_value).map_err(ParseRequestedPackage)?,
+                    RequestedPackage::try_from(install_value)
+                        .map_err(Self::Error::ParseRequestedPackage)?,
                 );
             }
         }
@@ -69,19 +81,36 @@ impl TryFrom<&dyn TableLike> for BuildpackConfig {
 }
 
 #[derive(Debug)]
-#[allow(dead_code)]
 pub(crate) enum ConfigError {
-    ReadConfig(std::io::Error),
+    CheckExists(PathBuf, std::io::Error),
+    ReadConfig(PathBuf, std::io::Error),
+    ParseConfig(PathBuf, ParseConfigError),
+}
+
+#[derive(Debug)]
+pub(crate) enum ParseConfigError {
     InvalidToml(toml_edit::TomlError),
-    PackageNameError(ParsePackageNameError),
     WrongConfigType,
     ParseRequestedPackage(ParseRequestedPackageError),
 }
 
+impl From<ConfigError> for DebianPackagesBuildpackError {
+    fn from(value: ConfigError) -> Self {
+        DebianPackagesBuildpackError::Config(value)
+    }
+}
+
+impl From<ConfigError> for libcnb::Error<DebianPackagesBuildpackError> {
+    fn from(value: ConfigError) -> Self {
+        Self::BuildpackError(value.into())
+    }
+}
+
 #[cfg(test)]
 mod test {
-    use super::*;
     use crate::debian::PackageName;
+
+    use super::*;
 
     #[test]
     fn test_deserialize() {
@@ -157,7 +186,7 @@ install = [
         "#
         .trim();
         match BuildpackConfig::from_str(toml).unwrap_err() {
-            ParseRequestedPackage(_) => {}
+            ParseConfigError::ParseRequestedPackage(_) => {}
             e => panic!("Not the expected error - {e:?}"),
         }
     }
@@ -175,7 +204,7 @@ install = [
         "#
         .trim();
         match BuildpackConfig::from_str(toml).unwrap_err() {
-            ParseRequestedPackage(_) => {}
+            ParseConfigError::ParseRequestedPackage(_) => {}
             e => panic!("Not the expected error - {e:?}"),
         }
     }
@@ -192,7 +221,7 @@ debian-packages = ["wrong"]
         "#
         .trim();
         match BuildpackConfig::from_str(toml).unwrap_err() {
-            WrongConfigType => {}
+            ParseConfigError::WrongConfigType => {}
             e => panic!("Not the expected error - {e:?}"),
         }
     }
@@ -204,7 +233,7 @@ debian-packages = ["wrong"]
         "
         .trim();
         match BuildpackConfig::from_str(toml).unwrap_err() {
-            InvalidToml(_) => {}
+            ParseConfigError::InvalidToml(_) => {}
             e => panic!("Not the expected error - {e:?}"),
         }
     }

--- a/src/config/buildpack_config.rs
+++ b/src/config/buildpack_config.rs
@@ -5,7 +5,6 @@ use std::str::FromStr;
 use indexmap::IndexSet;
 use toml_edit::{DocumentMut, TableLike};
 
-use crate::config::ConfigError::{CheckExists, ParseConfig, ReadConfig};
 use crate::config::{ParseRequestedPackageError, RequestedPackage};
 use crate::{BuildpackResult, DebianPackagesBuildpackError};
 
@@ -19,7 +18,7 @@ impl BuildpackConfig {
         Ok(config_file
             .as_ref()
             .try_exists()
-            .map_err(|e| CheckExists(config_file.as_ref().to_path_buf(), e))?)
+            .map_err(|e| ConfigError::CheckExists(config_file.as_ref().to_path_buf(), e))?)
     }
 }
 
@@ -28,9 +27,9 @@ impl TryFrom<PathBuf> for BuildpackConfig {
 
     fn try_from(value: PathBuf) -> Result<Self, Self::Error> {
         fs::read_to_string(&value)
-            .map_err(|e| ReadConfig(value.clone(), e))
+            .map_err(|e| ConfigError::ReadConfig(value.clone(), e))
             .and_then(|contents| {
-                BuildpackConfig::from_str(&contents).map_err(|e| ParseConfig(value, e))
+                BuildpackConfig::from_str(&contents).map_err(|e| ConfigError::ParseConfig(value, e))
             })
     }
 }

--- a/src/config/requested_package.rs
+++ b/src/config/requested_package.rs
@@ -1,7 +1,9 @@
+use std::str::FromStr;
+
+use toml_edit::{Formatted, InlineTable, Value};
+
 use crate::config::ParseRequestedPackageError::{InvalidPackageName, UnexpectedTomlValue};
 use crate::debian::{PackageName, ParsePackageNameError};
-use std::str::FromStr;
-use toml_edit::{Formatted, InlineTable, Value};
 
 #[derive(Debug, Eq, PartialEq, Hash)]
 pub(crate) struct RequestedPackage {
@@ -62,7 +64,6 @@ impl TryFrom<&InlineTable> for RequestedPackage {
 }
 
 #[derive(Debug)]
-#[allow(dead_code)]
 pub(crate) enum ParseRequestedPackageError {
     InvalidPackageName(ParsePackageNameError),
     UnexpectedTomlValue(Value),

--- a/src/config/requested_package.rs
+++ b/src/config/requested_package.rs
@@ -2,7 +2,6 @@ use std::str::FromStr;
 
 use toml_edit::{Formatted, InlineTable, Value};
 
-use crate::config::ParseRequestedPackageError::{InvalidPackageName, UnexpectedTomlValue};
 use crate::debian::{PackageName, ParsePackageNameError};
 
 #[derive(Debug, Eq, PartialEq, Hash)]
@@ -16,7 +15,8 @@ impl FromStr for RequestedPackage {
 
     fn from_str(package_name: &str) -> Result<Self, Self::Err> {
         Ok(RequestedPackage {
-            name: PackageName::from_str(package_name).map_err(InvalidPackageName)?,
+            name: PackageName::from_str(package_name)
+                .map_err(ParseRequestedPackageError::InvalidPackageName)?,
             skip_dependencies: false,
         })
     }
@@ -29,7 +29,9 @@ impl TryFrom<&Value> for RequestedPackage {
         match value {
             Value::String(formatted_string) => RequestedPackage::try_from(formatted_string),
             Value::InlineTable(inline_table) => RequestedPackage::try_from(inline_table),
-            _ => Err(UnexpectedTomlValue(value.clone())),
+            _ => Err(ParseRequestedPackageError::UnexpectedTomlValue(
+                value.clone(),
+            )),
         }
     }
 }
@@ -53,7 +55,7 @@ impl TryFrom<&InlineTable> for RequestedPackage {
                     .and_then(Value::as_str)
                     .unwrap_or_default(),
             )
-            .map_err(InvalidPackageName)?,
+            .map_err(ParseRequestedPackageError::InvalidPackageName)?,
 
             skip_dependencies: table
                 .get("skip_dependencies")

--- a/src/debian/architecture_name.rs
+++ b/src/debian/architecture_name.rs
@@ -33,7 +33,12 @@ impl Display for ArchitectureName {
 }
 
 #[derive(Debug)]
-#[allow(dead_code)] // TODO: remove this once error messages are added
+// Due to how this error rolls into the broader `Distro::try_from(Target)` implementation, the
+// architecture name stored in this struct isn't used directly which triggers a `dead_code`
+// warning. I could eliminate this by not capturing the architecture name that failed to parse
+// but that doesn't seem right. I'd rather keep this information attached to this struct even
+// if it's not used at this point in time.
+#[allow(dead_code)]
 pub(crate) struct UnsupportedArchitectureNameError(String);
 
 #[cfg(test)]

--- a/src/debian/distro.rs
+++ b/src/debian/distro.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::debian::ArchitectureName::{AMD_64, ARM_64};
 use crate::debian::{ArchitectureName, DistroCodename, Source};
+use crate::DebianPackagesBuildpackError;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub(crate) struct Distro {
@@ -43,7 +44,7 @@ impl TryFrom<&Target> for Distro {
                 architecture: target_arch.to_string(),
             })?;
 
-        match (name.as_str(), version.as_str()) {
+        match (name.to_lowercase().as_str(), version.as_str()) {
             ("ubuntu", "22.04") => Ok(Distro {
                 name,
                 version,
@@ -118,9 +119,14 @@ fn get_noble_source_list() -> Vec<Source> {
 }
 
 #[derive(Debug)]
-#[allow(dead_code)]
 pub(crate) struct UnsupportedDistroError {
     pub(crate) name: String,
     pub(crate) version: String,
     pub(crate) architecture: String,
+}
+
+impl From<UnsupportedDistroError> for libcnb::Error<DebianPackagesBuildpackError> {
+    fn from(value: UnsupportedDistroError) -> Self {
+        Self::BuildpackError(DebianPackagesBuildpackError::UnsupportedDistro(value))
+    }
 }

--- a/src/debian/package_name.rs
+++ b/src/debian/package_name.rs
@@ -28,7 +28,9 @@ impl FromStr for PackageName {
         if is_valid_package_name {
             Ok(PackageName(value.to_string()))
         } else {
-            Err(ParsePackageNameError(value.to_string()))
+            Err(ParsePackageNameError {
+                package_name: value.to_string(),
+            })
         }
     }
 }
@@ -40,7 +42,9 @@ impl Display for PackageName {
 }
 
 #[derive(Debug, PartialEq)]
-pub(crate) struct ParsePackageNameError(String);
+pub(crate) struct ParsePackageNameError {
+    pub(crate) package_name: String,
+}
 
 #[cfg(test)]
 mod tests {
@@ -75,7 +79,9 @@ mod tests {
         for invalid_name in invalid_names {
             assert_eq!(
                 PackageName::from_str(invalid_name).unwrap_err(),
-                ParsePackageNameError(invalid_name.to_string())
+                ParsePackageNameError {
+                    package_name: invalid_name.to_string()
+                }
             );
         }
     }

--- a/src/debian/repository_package.rs
+++ b/src/debian/repository_package.rs
@@ -134,25 +134,25 @@ impl Display for ParseRepositoryPackageError {
             ParseRepositoryPackageError::MissingPackageName => {
                 write!(
                     f,
-                    "There is an entry that is missing the required {PACKAGE_KEY} key"
+                    "There's an entry that's missing the required {PACKAGE_KEY} key."
                 )
             }
             ParseRepositoryPackageError::MissingVersion(package_name) => {
                 write!(
                     f,
-                    "Package {package_name} is missing the required {VERSION_KEY} key"
+                    "Package {package_name} is missing the required {VERSION_KEY} key."
                 )
             }
             ParseRepositoryPackageError::MissingFilename(package_name) => {
                 write!(
                     f,
-                    "Package {package_name} is missing the required {FILENAME_KEY} key"
+                    "Package {package_name} is missing the required {FILENAME_KEY} key."
                 )
             }
             ParseRepositoryPackageError::MissingSha256(package_name) => {
                 write!(
                     f,
-                    "Package {package_name} is missing the required {SHA256_KEY} key"
+                    "Package {package_name} is missing the required {SHA256_KEY} key."
                 )
             }
         }

--- a/src/debian/repository_package.rs
+++ b/src/debian/repository_package.rs
@@ -1,8 +1,8 @@
+use crate::debian::RepositoryUri;
+use bullet_stream::style;
 use rayon::iter::{IntoParallelIterator, ParallelBridge, ParallelIterator};
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Display, Formatter};
-
-use crate::debian::RepositoryUri;
 
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub(crate) struct RepositoryPackage {
@@ -134,25 +134,32 @@ impl Display for ParseRepositoryPackageError {
             ParseRepositoryPackageError::MissingPackageName => {
                 write!(
                     f,
-                    "There's an entry that's missing the required {PACKAGE_KEY} key."
+                    "There's an entry that's missing the required {package_key} key.",
+                    package_key = style::value(PACKAGE_KEY)
                 )
             }
             ParseRepositoryPackageError::MissingVersion(package_name) => {
                 write!(
                     f,
-                    "Package {package_name} is missing the required {VERSION_KEY} key."
+                    "Package {package_name} is missing the required {version_key} key.",
+                    package_name = style::value(package_name),
+                    version_key = style::value(VERSION_KEY)
                 )
             }
             ParseRepositoryPackageError::MissingFilename(package_name) => {
                 write!(
                     f,
-                    "Package {package_name} is missing the required {FILENAME_KEY} key."
+                    "Package {package_name} is missing the required {filename_key} key.",
+                    package_name = style::value(package_name),
+                    filename_key = style::value(FILENAME_KEY)
                 )
             }
             ParseRepositoryPackageError::MissingSha256(package_name) => {
                 write!(
                     f,
-                    "Package {package_name} is missing the required {SHA256_KEY} key."
+                    "Package {package_name} is missing the required {sha256_key} key.",
+                    package_name = style::value(package_name),
+                    sha256_key = style::value(SHA256_KEY)
                 )
             }
         }

--- a/src/determine_packages_to_install.rs
+++ b/src/determine_packages_to_install.rs
@@ -1,34 +1,36 @@
-use std::collections::{HashMap, HashSet};
-use std::fs::read_to_string;
-
 use apt_parser::Control;
 use indexmap::{IndexMap, IndexSet};
+use std::collections::{HashMap, HashSet};
+use std::fs::read_to_string;
+use std::path::PathBuf;
 
 use crate::config::RequestedPackage;
 use crate::debian::{PackageIndex, RepositoryPackage};
 use crate::determine_packages_to_install::DeterminePackagesToInstallError::{
     PackageNotFound, ParseSystemPackage, ReadSystemPackages, VirtualPackageMustBeSpecified,
 };
-
-type Result<T> = std::result::Result<T, DeterminePackagesToInstallError>;
+use crate::{BuildpackResult, DebianPackagesBuildpackError};
 
 pub(crate) fn determine_packages_to_install(
     package_index: &PackageIndex,
     requested_packages: IndexSet<RequestedPackage>,
-) -> Result<Vec<RepositoryPackage>> {
+) -> BuildpackResult<Vec<RepositoryPackage>> {
     println!("## Determining packages to install");
     println!();
 
-    let system_packages = read_to_string("/var/lib/dpkg/status")
-        .map_err(ReadSystemPackages)?
+    let system_packages_path = PathBuf::from("/var/lib/dpkg/status");
+    let system_packages = read_to_string(&system_packages_path)
+        .map_err(|e| ReadSystemPackages(system_packages_path.clone(), e))?
         .trim()
         .split("\n\n")
         .map(|control_data| {
             Control::from(control_data)
-                .map_err(ParseSystemPackage)
+                .map_err(|e| {
+                    ParseSystemPackage(system_packages_path.clone(), control_data.to_string(), e)
+                })
                 .map(|control| (control.package.to_string(), control))
         })
-        .collect::<Result<HashMap<_, _>>>()?;
+        .collect::<Result<HashMap<_, _>, _>>()?;
 
     let mut install_details = IndexMap::new();
     for requested_package in requested_packages {
@@ -71,7 +73,6 @@ pub(crate) fn determine_packages_to_install(
 //       The dependency solving done here is mostly for convenience. Any transitive packages added
 //       will be reported to the user and, if they aren't correct, the user may disable this dependency
 //       resolution on a per-package basis and specify a more appropriate set of packages.
-#[allow(clippy::too_many_lines)]
 fn visit(
     package: &str,
     skip_dependencies: bool,
@@ -79,7 +80,7 @@ fn visit(
     install_details: &mut IndexMap<String, InstallRecord>,
     system_packages: &HashMap<String, Control>,
     package_index: &PackageIndex,
-) -> Result<()> {
+) -> BuildpackResult<()> {
     if let Some(system_package) = system_packages.get(package) {
         // only show this message if the package is a top-level dependency
         if visit_stack.is_empty() {
@@ -175,9 +176,9 @@ fn get_provider_for_virtual_package<'a>(
     package: &str,
     package_index: &'a PackageIndex,
     visit_stack: &IndexSet<String>,
-) -> Result<&'a RepositoryPackage> {
+) -> BuildpackResult<&'a RepositoryPackage> {
     let providers = package_index.get_providers(package);
-    match providers.iter().collect::<Vec<_>>().as_slice() {
+    Ok(match providers.iter().collect::<Vec<_>>().as_slice() {
         [providing_package] => {
             package_index
                 .get_highest_available_version(providing_package)
@@ -195,21 +196,29 @@ fn get_provider_for_virtual_package<'a>(
         }
         [] => Err(PackageNotFound(package.to_string())),
         _ => Err(VirtualPackageMustBeSpecified(
+            package.to_string(),
             providers
                 .into_iter()
                 .map(ToString::to_string)
                 .collect::<HashSet<_>>(),
         )),
-    }
+    }?)
 }
 
 #[derive(Debug)]
-#[allow(dead_code)]
 pub(crate) enum DeterminePackagesToInstallError {
-    ReadSystemPackages(std::io::Error),
-    ParseSystemPackage(apt_parser::errors::APTError),
+    ReadSystemPackages(PathBuf, std::io::Error),
+    ParseSystemPackage(PathBuf, String, apt_parser::errors::APTError),
     PackageNotFound(String),
-    VirtualPackageMustBeSpecified(HashSet<String>),
+    VirtualPackageMustBeSpecified(String, HashSet<String>),
+}
+
+impl From<DeterminePackagesToInstallError> for libcnb::Error<DebianPackagesBuildpackError> {
+    fn from(value: DeterminePackagesToInstallError) -> Self {
+        Self::BuildpackError(DebianPackagesBuildpackError::DeterminePackagesToInstall(
+            value,
+        ))
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -231,6 +240,7 @@ mod test {
     use crate::determine_packages_to_install::{
         visit, DeterminePackagesToInstallError, InstallRecord,
     };
+    use crate::{BuildpackResult, DebianPackagesBuildpackError};
 
     #[test]
     fn install_package_already_on_the_system() {
@@ -309,18 +319,23 @@ mod test {
             .call()
             .unwrap_err();
 
-        match error {
-            DeterminePackagesToInstallError::VirtualPackageMustBeSpecified(names) => {
-                assert_eq!(
-                    names,
-                    HashSet::from([
-                        virtual_package_provider1.name,
-                        virtual_package_provider2.name
-                    ])
-                );
-            }
-            e => panic!("not the expected error: {e:?}"),
-        };
+        if let libcnb::Error::BuildpackError(
+            DebianPackagesBuildpackError::DeterminePackagesToInstall(
+                DeterminePackagesToInstallError::VirtualPackageMustBeSpecified(package, providers),
+            ),
+        ) = error
+        {
+            assert_eq!(package, virtual_package);
+            assert_eq!(
+                providers,
+                HashSet::from([
+                    virtual_package_provider1.name,
+                    virtual_package_provider2.name
+                ])
+            );
+        } else {
+            panic!("not the expected error: {error:?}")
+        }
     }
 
     #[test]
@@ -333,12 +348,16 @@ mod test {
             .call()
             .unwrap_err();
 
-        match error {
-            DeterminePackagesToInstallError::PackageNotFound(name) => {
-                assert_eq!(name, virtual_package.to_string());
-            }
-            e => panic!("not the expected error: {e:?}"),
-        };
+        if let libcnb::Error::BuildpackError(
+            DebianPackagesBuildpackError::DeterminePackagesToInstall(
+                DeterminePackagesToInstallError::PackageNotFound(name),
+            ),
+        ) = error
+        {
+            assert_eq!(name, virtual_package.to_string());
+        } else {
+            panic!("not the expected error: {error:?}")
+        }
     }
 
     #[test]
@@ -496,7 +515,7 @@ mod test {
         with_installed: Option<Vec<&RepositoryPackage>>,
         with_system_packages: Option<Vec<&RepositoryPackage>>,
         skip_dependencies: Option<bool>,
-    ) -> Result<IndexMap<String, InstallRecord>, DeterminePackagesToInstallError> {
+    ) -> BuildpackResult<IndexMap<String, InstallRecord>> {
         let package_to_install = install;
 
         let mut package_index = PackageIndex::default();

--- a/src/determine_packages_to_install.rs
+++ b/src/determine_packages_to_install.rs
@@ -229,18 +229,14 @@ struct InstallRecord {
 
 #[cfg(test)]
 mod test {
-    use std::collections::{BTreeSet, HashSet};
+    use super::*;
+
+    use std::collections::BTreeSet;
     use std::str::FromStr;
 
-    use apt_parser::Control;
     use bon::builder;
-    use indexmap::{IndexMap, IndexSet};
 
-    use crate::debian::{PackageIndex, RepositoryPackage, RepositoryUri};
-    use crate::determine_packages_to_install::{
-        visit, DeterminePackagesToInstallError, InstallRecord,
-    };
-    use crate::{BuildpackResult, DebianPackagesBuildpackError};
+    use crate::debian::RepositoryUri;
 
     #[test]
     fn install_package_already_on_the_system() {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -187,6 +187,10 @@ fn on_unsupported_distro_error(error: UnsupportedDistroError) -> ErrorMessage {
         .header("Unsupported distribution")
         .body(formatdoc! { "
             The {BUILDPACK_NAME} doesn't support the {name} {version} ({architecture}) distribution.
+
+            Supported distributions:
+            - Ubuntu 24.04 (amd64, arm64)
+            - Ubuntu 22.04 (amd64)
         " })
         .call()
 }
@@ -479,7 +483,7 @@ fn on_create_package_index_error(error: CreatePackageIndexError) -> ErrorMessage
                 .join("\n");
             let body_end = indoc! { "
                 Suggestions:
-                - Run the build again with a clean cache
+                - Run the build again with a clean cache.
             " };
             create_error()
                 .error_type(Internal)
@@ -556,7 +560,7 @@ fn on_determine_packages_to_install_error(error: DeterminePackagesToInstallError
                 .join("\n");
             let body_end = formatdoc! { "
                 Suggestions:
-                - Replace the virtual package {package} with one of the above providers
+                - Replace the virtual package {package} with one of the above providers.
             " };
             create_error()
                 .error_type(UserFacing(SuggestRetryBuild::Yes, SuggestSubmitIssue::No))

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -67,7 +67,7 @@ fn on_config_error(error: ConfigError) -> ErrorMessage {
                     the file can't be read.
 
                     Suggestions:
-                    - Ensure the file has read permissions
+                    - Ensure the file has read permissions.
                 " })
                 .debug_info(e.to_string())
                 .call()
@@ -87,13 +87,13 @@ fn on_config_error(error: ConfigError) -> ErrorMessage {
                 ParseConfigError::InvalidToml(error) => {
                     create_error()
                         .error_type(UserFacing(SuggestRetryBuild::Yes, SuggestSubmitIssue::No))
-                        .header(format!("Error parsing {config_file}"))
+                        .header(format!("Error parsing {config_file} with invalid TOML file"))
                         .body(formatdoc! { "
                             The {BUILDPACK_NAME} reads configuration from {config_file} to complete the build but \
-                            this file is not valid TOML.
+                            this file isn't a valid TOML file.
 
                             Suggestions:
-                            - Ensure the file conforms to the TOML format described at {toml_spec_url}
+                            - Ensure the file follows the TOML format described at {toml_spec_url}
                         " })
                         .debug_info(error.to_string())
                         .call()
@@ -102,17 +102,17 @@ fn on_config_error(error: ConfigError) -> ErrorMessage {
                 ParseConfigError::WrongConfigType => {
                     create_error()
                         .error_type(UserFacing(SuggestRetryBuild::Yes, SuggestSubmitIssue::No))
-                        .header(format!("Error parsing {config_file}"))
+                        .header(format!("Error parsing {config_file} with invalid key"))
                         .body(formatdoc! { "
-                            The {BUILDPACK_NAME} reads configuration from {config_file} to complete \
-                            the build but the configuration for the key {root_config_key} is not the \
-                            correct type. This value of this key is expected to be a TOML Table.
+                            The {BUILDPACK_NAME} reads the configuration from {config_file} to complete \
+                            the build but the configuration for the key {root_config_key} isn't the \
+                            correct type. The value of this key must be a TOML table.
 
                             Suggestions:
-                            - Refer to the buildpack documentation for this configuration at \
-                            {configuration_doc_url} for proper buildpack usage
-                            - Refer to the TOML documentation for more details on the TOML Table \
-                            type at {toml_spec_url}
+                            - See the buildpack documentation for the proper usage for this configuration at \
+                            {configuration_doc_url}
+                            - See the TOML documentation for more details on the TOML table type at \
+                            {toml_spec_url}
                         " })
                         .call()
                 }
@@ -123,19 +123,20 @@ fn on_config_error(error: ConfigError) -> ErrorMessage {
 
                         create_error()
                             .error_type(UserFacing(SuggestRetryBuild::Yes, SuggestSubmitIssue::No))
-                            .header(format!("Error parsing {config_file}"))
+                            .header(format!("Error parsing {config_file} with invalid package name"))
                             .body(formatdoc! { "
                                 The {BUILDPACK_NAME} reads configuration from {config_file} to \
-                                complete the build but an invalid package name ({invalid_package_name}) \
-                                was found in the key {root_config_key}.
+                                complete the build but we found an invalid package name {invalid_package_name} \
+                                in the key {root_config_key}.
 
-                                Package names must consist only of lower case letters (a-z), \
-                                digits (0-9), plus (+) and minus (-) signs, and periods (.). They \
+                                Package names must consist only of lowercase letters (a-z), \
+                                digits (0-9), plus (+) and minus (-) signs, and periods (.). Names \
                                 must be at least two characters long and must start with an alphanumeric \
-                                character. (See {debian_package_name_format_url}).
+                                character. See {debian_package_name_format_url}
 
                                 Suggestions:
-                                - Verify the package name at {package_search_url}
+                                - Verify the package name is correct and exists for the target distribution at \
+                                 {package_search_url}
                             " })
                             .call()
                     }
@@ -149,21 +150,21 @@ fn on_config_error(error: ConfigError) -> ErrorMessage {
 
                         create_error()
                             .error_type(UserFacing(SuggestRetryBuild::Yes, SuggestSubmitIssue::No))
-                            .header(format!("Error parsing {config_file}"))
+                            .header(format!("Error parsing {config_file} with invalid package format"))
                             .body(formatdoc! { "
                                 The {BUILDPACK_NAME} reads configuration from {config_file} to \
-                                complete the build but an invalid package format was found in the \
+                                complete the build but we found an invalid package format in the \
                                 key {root_config_key}.
 
-                                Packages are expected to be specified using the following TOML values:
+                                Packages must either be the following TOML values:
                                 - String (e.g.; {string_example})
-                                - Inline Table (e.g.; {inline_table_example})
+                                - Inline table (e.g.; {inline_table_example})
 
                                 Suggestions:
-                                - Refer to the buildpack documentation for this configuration at \
-                                {configuration_doc_url} for proper buildpack usage
-                                - Refer to the TOML documentation for more details on the TOML String \
-                                and Inline Table types at {toml_spec_url}
+                                - See the buildpack documentation for the proper usage for this configuration at \
+                                {configuration_doc_url}
+                                - See the TOML documentation for more details on the TOML string \
+                                and inline table types at {toml_spec_url}
                             " })
                             .debug_info(format!("Invalid type {value_type} with value {value}"))
                             .call()
@@ -185,8 +186,7 @@ fn on_unsupported_distro_error(error: UnsupportedDistroError) -> ErrorMessage {
         .error_type(Internal)
         .header("Unsupported distribution")
         .body(formatdoc! { "
-            The distribution {name} {version} ({architecture}) is not supported by the \
-            {BUILDPACK_NAME}.
+            The {BUILDPACK_NAME} doesn't support the {name} {version} ({architecture}) distribution.
         " })
         .call()
 }
@@ -201,7 +201,7 @@ fn on_create_package_index_error(error: CreatePackageIndexError) -> ErrorMessage
                 .error_type(Internal)
                 .header("No sources to update")
                 .body(indoc! { "
-                    No sources were configured for the distribution to update packages from.
+                    The distribution has no sources to update packages from.
                 " })
                 .call()
         }
@@ -211,8 +211,7 @@ fn on_create_package_index_error(error: CreatePackageIndexError) -> ErrorMessage
                 .error_type(Internal)
                 .header("Task failure while updating sources")
                 .body(indoc! { "
-                    A background task responsible for updating sources failed to execute to \
-                    completion.
+                    A background task responsible for updating sources failed to complete.
                 " })
                 .debug_info(e.to_string())
                 .call()
@@ -225,10 +224,10 @@ fn on_create_package_index_error(error: CreatePackageIndexError) -> ErrorMessage
                 .body(formatdoc! { "
                     For caching purposes, a unique layer name is generated for Debian Release files \
                     and Package indices based on their download urls. The generated name for the \
-                    following url was determined to be invalid:
+                    following url was invalid:
                     - {url}
 
-                    The invalid layer name can be found in the debug information above.
+                    You can find the invalid layer name in the debug information above.
                 " })
                 .debug_info(e.to_string())
                 .call()
@@ -240,11 +239,11 @@ fn on_create_package_index_error(error: CreatePackageIndexError) -> ErrorMessage
                 .header("Failed to request Release file")
                 .body(formatdoc! { "
                     While updating package sources, a request to download a Release file failed. \
-                    This may be due to an unstable network connection or an issue with the upstream \
+                    This error can occur due to an unstable network connection or an issue with the upstream \
                     Debian package repository.
 
                     Suggestions:
-                    - Check the status of {canonical_status_url} for any reported issues
+                    - Check the status of {canonical_status_url} for any reported issues.
                 " })
                 .debug_info(e.to_string())
                 .call()
@@ -256,11 +255,11 @@ fn on_create_package_index_error(error: CreatePackageIndexError) -> ErrorMessage
                 .header("Failed to download Release file")
                 .body(formatdoc! { "
                     While updating package sources, an error occurred while downloading a Release file. \
-                    This may be due to an unstable network connection or an issue with the upstream \
+                    This error can occur due to an unstable network connection or an issue with the upstream \
                     Debian package repository.
 
                     Suggestions:
-                    - Check the status of {canonical_status_url} for any reported issues
+                    - Check the status of {canonical_status_url} for any reported issues.
                 " })
                 .debug_info(e.to_string())
                 .call()
@@ -272,12 +271,12 @@ fn on_create_package_index_error(error: CreatePackageIndexError) -> ErrorMessage
                 .header("Failed to load verifying PGP certificate")
                 .body(indoc! { "
                     The PGP certificate used to verify downloaded release files failed to load. This \
-                    would indicate there is a problem with the format of the certificate file used \
-                    by this distribution.
+                    error indicates there's a problem with the format of the certificate file the \
+                    distribution uses.
 
                     Suggestions:
                     - Verify the format of the certificates found in the ./keys directory of this \
-                    buildpack's repository (see https://cirw.in/gpg-decoder)
+                    buildpack's repository. See https://cirw.in/gpg-decoder
                     - Extract new certificates by running the ./scripts/extract_keys.sh script found \
                     in this buildpack's repository.
                 " })
@@ -290,12 +289,12 @@ fn on_create_package_index_error(error: CreatePackageIndexError) -> ErrorMessage
                 .error_type(Internal)
                 .header("Failed to verify Release file")
                 .body(indoc! { "
-                    The PGP signature of the downloaded release file failed verification. This can \
-                    happen if the process for signing release files was changed by the maintainers \
-                    of the Debian repository.
+                    The PGP signature of the downloaded release file failed verification. This error can \
+                    occur if the maintainers of the Debian repository changed the process for signing \
+                    release files.
 
                     Suggestions:
-                    - Verify if the keys have changed by running the ./scripts/extract_keys.sh \
+                    - Verify if the keys changed by running the ./scripts/extract_keys.sh \
                     script found in this buildpack's repository.
                 " })
                 .debug_info(e.to_string())
@@ -332,12 +331,12 @@ fn on_create_package_index_error(error: CreatePackageIndexError) -> ErrorMessage
                 .error_type(UserFacing(SuggestRetryBuild::Yes, SuggestSubmitIssue::Yes))
                 .header("Failed to parse Release file data")
                 .body(formatdoc! { "
-                    The Release file data stored in {file} could not be parsed. This is most likely \
-                    a bug with this buildpack but could also be caused by cached data that is no \
-                    longer valid or an issue with the upstream repository.
+                    We couldn't parse the Release file data stored in {file}. This error is most likely \
+                    a buildpack bug. It can also be caused by cached data that's no longer valid or an \
+                    issue with the upstream repository.
 
                     Suggestions:
-                    - Run the build again with a clean cache
+                    - Run the build again with a clean cache.
                 " })
                 .debug_info(e.to_string())
                 .call()
@@ -347,11 +346,11 @@ fn on_create_package_index_error(error: CreatePackageIndexError) -> ErrorMessage
             let release_uri = style::url(release_uri.as_str());
             create_error()
                 .error_type(UserFacing(SuggestRetryBuild::Yes, SuggestSubmitIssue::Yes))
-                .header("Missing SHA256 Release Hash")
+                .header("Missing SHA256 Release hash")
                 .body(formatdoc! { "
-                    The Release file from {release_uri} is missing the SHA256 key which, according to \
-                    the documented Debian repository format is required. This is most likely an issue \
-                    with the upstream repository. (See https://wiki.debian.org/DebianRepository/Format)
+                    The Release file from {release_uri} is missing the SHA256 key which is required \
+                    according to the documented Debian repository format. This error is most likely an issue \
+                    with the upstream repository. See https://wiki.debian.org/DebianRepository/Format
                 " })
                 .call()
         }
@@ -364,11 +363,11 @@ fn on_create_package_index_error(error: CreatePackageIndexError) -> ErrorMessage
                 .header("Missing Package Index")
                 .body(formatdoc! { "
                     The Release file from {release_uri} is missing an entry for {package_index} within \
-                    the SHA256 section. This is most likely a bug with this buildpack but could also \
+                    the SHA256 section. This error is most likely a buildpack bug but can also \
                     be an issue with the upstream repository.
 
                     Suggestions:
-                    - Verify if {package_index} is found under the SHA256 section of {release_uri}
+                    - Verify if {package_index} is under the SHA256 section of {release_uri}
                 " })
                 .call()
         }
@@ -379,11 +378,11 @@ fn on_create_package_index_error(error: CreatePackageIndexError) -> ErrorMessage
                 .header("Failed to request Package Index file")
                 .body(formatdoc! { "
                     While updating package sources, a request to download a Package Index file failed. \
-                    This may be due to an unstable network connection or an issue with the upstream \
+                    This error can occur due to an unstable network connection or an issue with the upstream \
                     Debian package repository.
 
                     Suggestions:
-                    - Check the status of {canonical_status_url} for any reported issues
+                    - Check the status of {canonical_status_url} for any reported issues.
                 " })
                 .debug_info(e.to_string())
                 .call()
@@ -408,11 +407,11 @@ fn on_create_package_index_error(error: CreatePackageIndexError) -> ErrorMessage
                 .header("Failed to download Package Index file")
                 .body(formatdoc! { "
                     While updating package sources, an error occurred while downloading a Package Index \
-                    file to {file}. This may be due to an unstable network connection or an issue \
+                    file to {file}. This error can occur due to an unstable network connection or an issue \
                     with the upstream Debian package repository.
 
                     Suggestions:
-                    - Check the status of {canonical_status_url} for any reported issues
+                    - Check the status of {canonical_status_url} for any reported issues.
                 " })
                 .debug_info(e.to_string())
                 .call()
@@ -431,12 +430,12 @@ fn on_create_package_index_error(error: CreatePackageIndexError) -> ErrorMessage
                 .header("Package Index checksum verification failed")
                 .body(formatdoc! { "
                     While updating package sources, an error occurred while verifying the checksum \
-                    of the Package Index at {url}. This may be due to an issue with the upstream \
+                    of the Package Index at {url}. This error can occur due to an issue with the upstream \
                     Debian package repository.
 
                     Checksum:
-                    - Expected - {expected}
-                    - Actual - {actual}
+                    - Expected: {expected}
+                    - Actual: {actual}
                 " })
                 .call()
         }
@@ -446,8 +445,7 @@ fn on_create_package_index_error(error: CreatePackageIndexError) -> ErrorMessage
                 .error_type(Internal)
                 .header("Task failure while reading Package Index data")
                 .body(indoc! { "
-                    A background task responsible for reading Package Index data failed to execute to \
-                    completion.
+                    A background task responsible for reading Package Index data failed to complete.
                 " })
                 .debug_info(e.to_string())
                 .call()
@@ -468,9 +466,9 @@ fn on_create_package_index_error(error: CreatePackageIndexError) -> ErrorMessage
         CreatePackageIndexError::ParsePackages(file, errors) => {
             let file = file_value(file);
             let body_start = formatdoc! { "
-                The Package Index file data stored in {file} could not be parsed. This is most likely \
-                a bug with this buildpack but could also be caused by cached data that is no \
-                longer valid or an issue with the upstream repository.
+                We can't parse the Package Index file data stored in {file}. This error is most likely \
+                a buildpack bug. It can also be caused by cached data that's no longer valid or an issue \
+                with the upstream repository.
 
                 Parsing errors:
             " }.trim_end().to_string();
@@ -527,10 +525,9 @@ fn on_determine_packages_to_install_error(error: DeterminePackagesToInstallError
                 .error_type(UserFacing(SuggestRetryBuild::Yes, SuggestSubmitIssue::No))
                 .header("Package not found")
                 .body(formatdoc! { "
-                    No package matching the name {package_name} could be found in the Package Index. \
-                    If this package is listed in the packages to install for this buildpack then it \
-                    is most likely due to the package being misspelled. Otherwise, it could be an \
-                    issue with the upstream Debian package repository.
+                    We can't find {package_name} in the Package Index. If this package is listed in the \
+                    packages to install for this buildpack then the name is most likely misspelled. Otherwise, \
+                    it can be an issue with the upstream Debian package repository.
 
                     Suggestions:
                     - Verify the package name is correct and exists for the target distribution at \
@@ -545,7 +542,7 @@ fn on_determine_packages_to_install_error(error: DeterminePackagesToInstallError
                 Sometimes there are several packages which offer more-or-less the same functionality. \
                 In this case, Debian repositories define a virtual package and one or more actual \
                 packages provide an implementation for this virtual package. When multiple providers \
-                are found for a requested package, this buildpack cannot automatically choose which \
+                are found for a requested package, this buildpack can't automatically choose which \
                 one is the desired implementation.
 
                 Providing packages:
@@ -566,9 +563,7 @@ fn on_determine_packages_to_install_error(error: DeterminePackagesToInstallError
                 .header(format!(
                     "Multiple providers were found for the package {package}"
                 ))
-                .body(format!(
-                    "{body_start}\n\n{body_provider_details}\n\n{body_end}"
-                ))
+                .body(format!("{body_start}{body_provider_details}\n\n{body_end}"))
                 .call()
         }
     }
@@ -583,9 +578,8 @@ fn on_install_packages_error(error: InstallPackagesError) -> ErrorMessage {
             .error_type(Internal)
             .header("Task failure while installing packages")
             .body(indoc! { "
-            A background task responsible for installing failed to execute to \
-                    completion.
-                " })
+                A background task responsible for installing failed to complete.
+            " })
             .debug_info(e.to_string())
             .call(),
 
@@ -597,7 +591,7 @@ fn on_install_packages_error(error: InstallPackagesError) -> ErrorMessage {
                 .header(format!("Could not determine file name for {package}"))
                 .body(formatdoc! { "
                     The package information for {package} contains a Filename field of {filename} \
-                    which failed to produce a valid name to use as a download path.
+                    which produces an invalid name to use as a download path.
                 " })
                 .call()
         }
@@ -609,11 +603,11 @@ fn on_install_packages_error(error: InstallPackagesError) -> ErrorMessage {
                 .header("Failed to request package")
                 .body(formatdoc! { "
                     While installing packages, an error occurred while downloading {package}. \
-                    This may be due to an unstable network connection or an issue \
+                    This error can occur due to an unstable network connection or an issue \
                     with the upstream Debian package repository.
 
                     Suggestions:
-                    - Check the status of {canonical_status_url} for any reported issues
+                    - Check the status of {canonical_status_url} for any reported issues.
                 " })
                 .debug_info(e.to_string())
                 .call()
@@ -628,11 +622,11 @@ fn on_install_packages_error(error: InstallPackagesError) -> ErrorMessage {
                 .header("Failed to download package")
                 .body(formatdoc! { "
                     An unexpected I/O error occured while downloading {package} from {download_url} \
-                    to {destination_path}. This may be due to an unstable network connection or an issue \
+                    to {destination_path}. This error can occur due to an unstable network connection or an issue \
                     with the upstream Debian package repository.
 
                     Suggestions:
-                    - Check the status of {canonical_status_url} for any reported issues
+                    - Check the status of {canonical_status_url} for any reported issues.
                 " })
                 .debug_info(e.to_string())
                 .call()
@@ -651,11 +645,11 @@ fn on_install_packages_error(error: InstallPackagesError) -> ErrorMessage {
                 .header("Package checksum verification failed")
                 .body(formatdoc! { "
                     An error occurred while verifying the checksum of the package at {url}. \
-                    This may be due to an issue with the upstream Debian package repository.
+                    This error can occur due to an issue with the upstream Debian package repository.
 
                     Checksum:
-                    - Expected - {expected}
-                    - Actual - {actual}
+                    - Expected: {expected}
+                    - Actual: {actual}
                 " })
                 .call()
         }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -77,7 +77,8 @@ fn on_config_error(error: ConfigError) -> ErrorMessage {
             let config_file = file_value(config_file);
             let toml_spec_url = style::url("https://toml.io/en/v1.0.0");
             let root_config_key = style::value("[com.heroku.buildpacks.debian-packages]");
-            let configuration_doc_url = style::url("https://github.com/heroku/buildpacks-debian-packages?tab=readme-ov-file#configuration");
+            let configuration_doc_url =
+                style::url("https://github.com/heroku/buildpacks-debian-packages#configuration");
             let debian_package_name_format_url = style::url(
                 "https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-source",
             );
@@ -948,7 +949,7 @@ mod tests {
                 !
                 ! Suggestions:
                 ! - See the buildpack documentation for the proper usage for this configuration at \
-                https://github.com/heroku/buildpacks-debian-packages?tab=readme-ov-file#configuration
+                https://github.com/heroku/buildpacks-debian-packages#configuration
                 ! - See the TOML documentation for more details on the TOML table type at \
                 https://toml.io/en/v1.0.0
                 !
@@ -1066,7 +1067,7 @@ mod tests {
                 !
                 ! Suggestions:
                 ! - See the buildpack documentation for the proper usage for this configuration at \
-                https://github.com/heroku/buildpacks-debian-packages?tab=readme-ov-file#configuration
+                https://github.com/heroku/buildpacks-debian-packages#configuration
                 ! - See the TOML documentation for more details on the TOML string and inline \
                 table types at https://toml.io/en/v1.0.0
                 !

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,857 @@
+use crate::config::{ConfigError, ParseConfigError, ParseRequestedPackageError};
+use crate::create_package_index::CreatePackageIndexError;
+use crate::debian::UnsupportedDistroError;
+use crate::determine_packages_to_install::DeterminePackagesToInstallError;
+use crate::errors::ErrorType::{Framework, Internal, UserFacing};
+use crate::install_packages::InstallPackagesError;
+use crate::DebianPackagesBuildpackError;
+use std::collections::BTreeSet;
+
+use bon::builder;
+use bullet_stream::{style, Print};
+use indoc::{formatdoc, indoc};
+use libcnb::Error;
+use std::io::Write;
+use std::path::Path;
+
+const BUILDPACK_NAME: &str = "Heroku Deb Packages buildpack";
+
+pub(crate) fn on_error<W>(error: Error<DebianPackagesBuildpackError>, writer: W)
+where
+    W: Write + Sync + Send + 'static,
+{
+    print_error(
+        match error {
+            Error::BuildpackError(e) => on_buildpack_error(e),
+            e => on_framework_error(&e),
+        },
+        writer,
+    );
+}
+
+fn on_buildpack_error(error: DebianPackagesBuildpackError) -> ErrorMessage {
+    match error {
+        DebianPackagesBuildpackError::Config(e) => on_config_error(e),
+        DebianPackagesBuildpackError::UnsupportedDistro(e) => on_unsupported_distro_error(e),
+        DebianPackagesBuildpackError::CreatePackageIndex(e) => on_create_package_index_error(e),
+        DebianPackagesBuildpackError::DeterminePackagesToInstall(e) => {
+            on_determine_packages_to_install_error(e)
+        }
+        DebianPackagesBuildpackError::InstallPackages(e) => on_install_packages_error(e),
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+fn on_config_error(error: ConfigError) -> ErrorMessage {
+    match error {
+        ConfigError::CheckExists(config_file, e) => {
+            let config_file = file_value(config_file);
+            create_error()
+                .error_type(UserFacing(SuggestRetryBuild::No, SuggestSubmitIssue::No))
+                .header("Unable to complete buildpack detection")
+                .body(formatdoc! { "
+                    An unexpected I/O error occurred while checking {config_file} to determine if the \
+                    {BUILDPACK_NAME} is compatible for this application.
+                " })
+                .debug_info(e.to_string())
+                .call()
+        }
+
+        ConfigError::ReadConfig(config_file, e) => {
+            let config_file = file_value(config_file);
+            create_error()
+                .error_type(UserFacing(SuggestRetryBuild::Yes, SuggestSubmitIssue::No))
+                .header(format!("Error reading {config_file}"))
+                .body(formatdoc! { "
+                    The {BUILDPACK_NAME} reads configuration from {config_file} to complete the build but \
+                    the file can't be read.
+
+                    Suggestions:
+                    - Ensure the file has read permissions
+                " })
+                .debug_info(e.to_string())
+                .call()
+        }
+
+        ConfigError::ParseConfig(config_file, error) => {
+            let config_file = file_value(config_file);
+            let toml_spec_url = style::url("https://toml.io/en/v1.0.0");
+            let root_config_key = style::value("[com.heroku.buildpacks.debian-packages]");
+            let configuration_doc_url = style::url("https://github.com/heroku/buildpacks-debian-packages?tab=readme-ov-file#configuration");
+            let debian_package_name_format_url = style::url(
+                "https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-source",
+            );
+            let package_search_url = get_package_search_url();
+
+            match error {
+                ParseConfigError::InvalidToml(error) => {
+                    create_error()
+                        .error_type(UserFacing(SuggestRetryBuild::Yes, SuggestSubmitIssue::No))
+                        .header(format!("Error parsing {config_file}"))
+                        .body(formatdoc! { "
+                            The {BUILDPACK_NAME} reads configuration from {config_file} to complete the build but \
+                            this file is not valid TOML.
+
+                            Suggestions:
+                            - Ensure the file conforms to the TOML format described at {toml_spec_url}
+                        " })
+                        .debug_info(error.to_string())
+                        .call()
+                }
+
+                ParseConfigError::WrongConfigType => {
+                    create_error()
+                        .error_type(UserFacing(SuggestRetryBuild::Yes, SuggestSubmitIssue::No))
+                        .header(format!("Error parsing {config_file}"))
+                        .body(formatdoc! { "
+                            The {BUILDPACK_NAME} reads configuration from {config_file} to complete \
+                            the build but the configuration for the key {root_config_key} is not the \
+                            correct type. This value of this key is expected to be a TOML Table.
+
+                            Suggestions:
+                            - Refer to the buildpack documentation for this configuration at \
+                            {configuration_doc_url} for proper buildpack usage
+                            - Refer to the TOML documentation for more details on the TOML Table \
+                            type at {toml_spec_url}
+                        " })
+                        .call()
+                }
+
+                ParseConfigError::ParseRequestedPackage(error) => match error {
+                    ParseRequestedPackageError::InvalidPackageName(error) => {
+                        let invalid_package_name = style::value(error.package_name);
+
+                        create_error()
+                            .error_type(UserFacing(SuggestRetryBuild::Yes, SuggestSubmitIssue::No))
+                            .header(format!("Error parsing {config_file}"))
+                            .body(formatdoc! { "
+                                The {BUILDPACK_NAME} reads configuration from {config_file} to \
+                                complete the build but an invalid package name ({invalid_package_name}) \
+                                was found in the key {root_config_key}.
+
+                                Package names must consist only of lower case letters (a-z), \
+                                digits (0-9), plus (+) and minus (-) signs, and periods (.). They \
+                                must be at least two characters long and must start with an alphanumeric \
+                                character. (See {debian_package_name_format_url}).
+
+                                Suggestions:
+                                - Verify the package name at {package_search_url}
+                            " })
+                            .call()
+                    }
+
+                    ParseRequestedPackageError::UnexpectedTomlValue(value) => {
+                        let string_example = "\"package-name\"";
+                        let inline_table_example =
+                            r#"{ name = "package-name", skip_dependencies = true }"#;
+                        let value_type = style::value(value.type_name());
+                        let value = style::value(value.to_string());
+
+                        create_error()
+                            .error_type(UserFacing(SuggestRetryBuild::Yes, SuggestSubmitIssue::No))
+                            .header(format!("Error parsing {config_file}"))
+                            .body(formatdoc! { "
+                                The {BUILDPACK_NAME} reads configuration from {config_file} to \
+                                complete the build but an invalid package format was found in the \
+                                key {root_config_key}.
+
+                                Packages are expected to be specified using the following TOML values:
+                                - String (e.g.; {string_example})
+                                - Inline Table (e.g.; {inline_table_example})
+
+                                Suggestions:
+                                - Refer to the buildpack documentation for this configuration at \
+                                {configuration_doc_url} for proper buildpack usage
+                                - Refer to the TOML documentation for more details on the TOML String \
+                                and Inline Table types at {toml_spec_url}
+                            " })
+                            .debug_info(format!("Invalid type {value_type} with value {value}"))
+                            .call()
+                    }
+                },
+            }
+        }
+    }
+}
+
+fn on_unsupported_distro_error(error: UnsupportedDistroError) -> ErrorMessage {
+    let UnsupportedDistroError {
+        name,
+        version,
+        architecture,
+    } = error;
+
+    create_error()
+        .error_type(Internal)
+        .header("Unsupported distribution")
+        .body(formatdoc! { "
+            The distribution {name} {version} ({architecture}) is not supported by the \
+            {BUILDPACK_NAME}.
+        " })
+        .call()
+}
+
+#[allow(clippy::too_many_lines)]
+fn on_create_package_index_error(error: CreatePackageIndexError) -> ErrorMessage {
+    let canonical_status_url = get_canonical_status_url();
+
+    match error {
+        CreatePackageIndexError::NoSources => {
+            create_error()
+                .error_type(Internal)
+                .header("No sources to update")
+                .body(indoc! { "
+                    No sources were configured for the distribution to update packages from.
+                " })
+                .call()
+        }
+
+        CreatePackageIndexError::TaskFailed(e) => {
+            create_error()
+                .error_type(Internal)
+                .header("Task failure while updating sources")
+                .body(indoc! { "
+                    A background task responsible for updating sources failed to execute to \
+                    completion.
+                " })
+                .debug_info(e.to_string())
+                .call()
+        }
+
+        CreatePackageIndexError::InvalidLayerName(url, e) => {
+            create_error()
+                .error_type(Internal)
+                .header("Invalid layer name")
+                .body(formatdoc! { "
+                    For caching purposes, a unique layer name is generated for Debian Release files \
+                    and Package indices based on their download urls. The generated name for the \
+                    following url was determined to be invalid:
+                    - {url}
+
+                    The invalid layer name can be found in the debug information above.
+                " })
+                .debug_info(e.to_string())
+                .call()
+        }
+
+        CreatePackageIndexError::GetReleaseRequest(e) => {
+            create_error()
+                .error_type(UserFacing(SuggestRetryBuild::Yes, SuggestSubmitIssue::Yes))
+                .header("Failed to request Release file")
+                .body(formatdoc! { "
+                    While updating package sources, a request to download a Release file failed. \
+                    This may be due to an unstable network connection or an issue with the upstream \
+                    Debian package repository.
+
+                    Suggestions:
+                    - Check the status of {canonical_status_url} for any reported issues
+                " })
+                .debug_info(e.to_string())
+                .call()
+        }
+
+        CreatePackageIndexError::ReadGetReleaseResponse(e) => {
+            create_error()
+                .error_type(UserFacing(SuggestRetryBuild::Yes, SuggestSubmitIssue::Yes))
+                .header("Failed to download Release file")
+                .body(formatdoc! { "
+                    While updating package sources, an error occurred while downloading a Release file. \
+                    This may be due to an unstable network connection or an issue with the upstream \
+                    Debian package repository.
+
+                    Suggestions:
+                    - Check the status of {canonical_status_url} for any reported issues
+                " })
+                .debug_info(e.to_string())
+                .call()
+        }
+
+        CreatePackageIndexError::CreatePgpCertificate(e) => {
+            create_error()
+                .error_type(Internal)
+                .header("Failed to load verifying PGP certificate")
+                .body(indoc! { "
+                    The PGP certificate used to verify downloaded release files failed to load. This \
+                    would indicate there is a problem with the format of the certificate file used \
+                    by this distribution.
+
+                    Suggestions:
+                    - Verify the format of the certificates found in the ./keys directory of this \
+                    buildpack's repository (see https://cirw.in/gpg-decoder)
+                    - Extract new certificates by running the ./scripts/extract_keys.sh script found \
+                    in this buildpack's repository.
+                " })
+                .debug_info(e.to_string())
+                .call()
+        }
+
+        CreatePackageIndexError::CreatePgpVerifier(e) => {
+            create_error()
+                .error_type(Internal)
+                .header("Failed to verify Release file")
+                .body(indoc! { "
+                    The PGP signature of the downloaded release file failed verification. This can \
+                    happen if the process for signing release files was changed by the maintainers \
+                    of the Debian repository.
+
+                    Suggestions:
+                    - Verify if the keys have changed by running the ./scripts/extract_keys.sh \
+                    script found in this buildpack's repository.
+                " })
+                .debug_info(e.to_string())
+                .call()
+        }
+
+        CreatePackageIndexError::WriteReleaseLayer(file, e) => {
+            let file = file_value(file);
+            create_error()
+                .error_type(Internal)
+                .header("Failed to write Release file to layer")
+                .body(formatdoc! { "
+                    An unexpected I/O error occurred while writing release data to {file}.
+                " })
+                .debug_info(e.to_string())
+                .call()
+        }
+
+        CreatePackageIndexError::ReadReleaseFile(file, e) => {
+            let file = file_value(file);
+            create_error()
+                .error_type(Internal)
+                .header("Failed to read Release file from layer")
+                .body(formatdoc! { "
+                    An unexpected I/O error occurred while reading Release data from {file}.
+                " })
+                .debug_info(e.to_string())
+                .call()
+        }
+
+        CreatePackageIndexError::ParseReleaseFile(file, e) => {
+            let file = file_value(file);
+            create_error()
+                .error_type(UserFacing(SuggestRetryBuild::Yes, SuggestSubmitIssue::Yes))
+                .header("Failed to parse Release file data")
+                .body(formatdoc! { "
+                    The Release file data stored in {file} could not be parsed. This is most likely \
+                    a bug with this buildpack but could also be caused by cached data that is no \
+                    longer valid or an issue with the upstream repository.
+
+                    Suggestions:
+                    - Run the build again with a clean cache
+                " })
+                .debug_info(e.to_string())
+                .call()
+        }
+
+        CreatePackageIndexError::MissingSha256ReleaseHashes(release_uri) => {
+            let release_uri = style::url(release_uri.as_str());
+            create_error()
+                .error_type(UserFacing(SuggestRetryBuild::Yes, SuggestSubmitIssue::Yes))
+                .header("Missing SHA256 Release Hash")
+                .body(formatdoc! { "
+                    The Release file from {release_uri} is missing the SHA256 key which, according to \
+                    the documented Debian repository format is required. This is most likely an issue \
+                    with the upstream repository. (See https://wiki.debian.org/DebianRepository/Format)
+                " })
+                .call()
+        }
+
+        CreatePackageIndexError::MissingPackageIndexReleaseHash(release_uri, package_index) => {
+            let release_uri = style::url(release_uri.as_str());
+            let package_index = style::value(package_index);
+            create_error()
+                .error_type(UserFacing(SuggestRetryBuild::Yes, SuggestSubmitIssue::Yes))
+                .header("Missing Package Index")
+                .body(formatdoc! { "
+                    The Release file from {release_uri} is missing an entry for {package_index} within \
+                    the SHA256 section. This is most likely a bug with this buildpack but could also \
+                    be an issue with the upstream repository.
+
+                    Suggestions:
+                    - Verify if {package_index} is found under the SHA256 section of {release_uri}
+                " })
+                .call()
+        }
+
+        CreatePackageIndexError::GetPackagesRequest(e) => {
+            create_error()
+                .error_type(UserFacing(SuggestRetryBuild::Yes, SuggestSubmitIssue::Yes))
+                .header("Failed to request Package Index file")
+                .body(formatdoc! { "
+                    While updating package sources, a request to download a Package Index file failed. \
+                    This may be due to an unstable network connection or an issue with the upstream \
+                    Debian package repository.
+
+                    Suggestions:
+                    - Check the status of {canonical_status_url} for any reported issues
+                " })
+                .debug_info(e.to_string())
+                .call()
+        }
+
+        CreatePackageIndexError::WritePackagesLayer(file, e) => {
+            let file = file_value(file);
+            create_error()
+                .error_type(Internal)
+                .header("Failed to write Package Index file to layer")
+                .body(formatdoc! { "
+                    An unexpected I/O error occurred while writing Package Index data to {file}.
+                " })
+                .debug_info(e.to_string())
+                .call()
+        }
+
+        CreatePackageIndexError::WritePackageIndexFromResponse(file, e) => {
+            let file = file_value(file);
+            create_error()
+                .error_type(UserFacing(SuggestRetryBuild::Yes, SuggestSubmitIssue::Yes))
+                .header("Failed to download Package Index file")
+                .body(formatdoc! { "
+                    While updating package sources, an error occurred while downloading a Package Index \
+                    file to {file}. This may be due to an unstable network connection or an issue \
+                    with the upstream Debian package repository.
+
+                    Suggestions:
+                    - Check the status of {canonical_status_url} for any reported issues
+                " })
+                .debug_info(e.to_string())
+                .call()
+        }
+
+        CreatePackageIndexError::ChecksumFailed {
+            url,
+            expected,
+            actual,
+        } => {
+            let url = style::url(url);
+            let expected = style::value(expected);
+            let actual = style::value(actual);
+            create_error()
+                .error_type(UserFacing(SuggestRetryBuild::Yes, SuggestSubmitIssue::No))
+                .header("Package Index checksum verification failed")
+                .body(formatdoc! { "
+                    While updating package sources, an error occurred while verifying the checksum \
+                    of the Package Index at {url}. This may be due to an issue with the upstream \
+                    Debian package repository.
+
+                    Checksum:
+                    - Expected - {expected}
+                    - Actual - {actual}
+                " })
+                .call()
+        }
+
+        CreatePackageIndexError::CpuTaskFailed(e) => {
+            create_error()
+                .error_type(Internal)
+                .header("Task failure while reading Package Index data")
+                .body(indoc! { "
+                    A background task responsible for reading Package Index data failed to execute to \
+                    completion.
+                " })
+                .debug_info(e.to_string())
+                .call()
+        }
+
+        CreatePackageIndexError::ReadPackagesFile(file, e) => {
+            let file = file_value(file);
+            create_error()
+                .error_type(Internal)
+                .header("Failed to read Package Index file")
+                .body(formatdoc! { "
+                    An unexpected I/O error occurred while reading Package Index data from {file}.
+                " })
+                .debug_info(e.to_string())
+                .call()
+        }
+
+        CreatePackageIndexError::ParsePackages(file, errors) => {
+            let file = file_value(file);
+            let body_start = formatdoc! { "
+                The Package Index file data stored in {file} could not be parsed. This is most likely \
+                a bug with this buildpack but could also be caused by cached data that is no \
+                longer valid or an issue with the upstream repository.
+
+                Parsing errors:
+            " }.trim_end().to_string();
+            let body_error_details = errors
+                .iter()
+                .map(|e| format!("- {e}"))
+                .collect::<Vec<_>>()
+                .join("\n");
+            let body_end = indoc! { "
+                Suggestions:
+                - Run the build again with a clean cache
+            " };
+            create_error()
+                .error_type(Internal)
+                .header("Failed to parse Package Index file")
+                .body(format!(
+                    "{body_start}\n{body_error_details}\n\n{body_end}"
+                ))
+                .call()
+        }
+    }
+}
+
+fn on_determine_packages_to_install_error(error: DeterminePackagesToInstallError) -> ErrorMessage {
+    match error {
+        DeterminePackagesToInstallError::ReadSystemPackages(file, e) => {
+            let file = file_value(file);
+            create_error()
+                .error_type(Internal)
+                .header("Failed to read system packages")
+                .body(formatdoc! { "
+                    An unexpected I/O error occurred while reading system packages from {file}.
+                "})
+                .debug_info(e.to_string())
+                .call()
+        }
+
+        DeterminePackagesToInstallError::ParseSystemPackage(file, package_data, e) => {
+            let file = file_value(file);
+            create_error()
+                .error_type(Internal)
+                .header("Failed to parse system package")
+                .body(formatdoc! { "
+                    An unexpected parsing error occurred while reading system packages from {file}.
+                "})
+                .debug_info(format!("{e}\n\nPackage:\n{package_data}"))
+                .call()
+        }
+
+        DeterminePackagesToInstallError::PackageNotFound(package_name) => {
+            let package_name = style::value(package_name);
+            let package_search_url = get_package_search_url();
+            create_error()
+                .error_type(UserFacing(SuggestRetryBuild::Yes, SuggestSubmitIssue::No))
+                .header("Package not found")
+                .body(formatdoc! { "
+                    No package matching the name {package_name} could be found in the Package Index. \
+                    If this package is listed in the packages to install for this buildpack then it \
+                    is most likely due to the package being misspelled. Otherwise, it could be an \
+                    issue with the upstream Debian package repository.
+
+                    Suggestions:
+                    - Verify the package name is correct and exists for the target distribution at \
+                    {package_search_url}
+                " })
+                .call()
+        }
+
+        DeterminePackagesToInstallError::VirtualPackageMustBeSpecified(package, providers) => {
+            let package = style::value(package);
+            let body_start = indoc! { "
+                Sometimes there are several packages which offer more-or-less the same functionality. \
+                In this case, Debian repositories define a virtual package and one or more actual \
+                packages provide an implementation for this virtual package. When multiple providers \
+                are found for a requested package, this buildpack cannot automatically choose which \
+                one is the desired implementation.
+
+                Providing packages:
+            " };
+            let body_provider_details = providers
+                .iter()
+                .collect::<BTreeSet<_>>()
+                .iter()
+                .map(|provider| format!("- {provider}"))
+                .collect::<Vec<_>>()
+                .join("\n");
+            let body_end = formatdoc! { "
+                Suggestions:
+                - Replace the virtual package {package} with one of the above providers
+            " };
+            create_error()
+                .error_type(UserFacing(SuggestRetryBuild::Yes, SuggestSubmitIssue::No))
+                .header(format!(
+                    "Multiple providers were found for the package {package}"
+                ))
+                .body(format!(
+                    "{body_start}\n\n{body_provider_details}\n\n{body_end}"
+                ))
+                .call()
+        }
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+fn on_install_packages_error(error: InstallPackagesError) -> ErrorMessage {
+    let canonical_status_url = get_canonical_status_url();
+
+    match error {
+        InstallPackagesError::TaskFailed(e) => create_error()
+            .error_type(Internal)
+            .header("Task failure while installing packages")
+            .body(indoc! { "
+            A background task responsible for installing failed to execute to \
+                    completion.
+                " })
+            .debug_info(e.to_string())
+            .call(),
+
+        InstallPackagesError::InvalidFilename(package, filename) => {
+            let package = style::value(package);
+            let filename = style::value(filename);
+            create_error()
+                .error_type(Internal)
+                .header(format!("Could not determine file name for {package}"))
+                .body(formatdoc! { "
+                    The package information for {package} contains a Filename field of {filename} \
+                    which failed to produce a valid name to use as a download path.
+                " })
+                .call()
+        }
+
+        InstallPackagesError::RequestPackage(package, e) => {
+            let package = style::value(package);
+            create_error()
+                .error_type(UserFacing(SuggestRetryBuild::Yes, SuggestSubmitIssue::Yes))
+                .header("Failed to request package")
+                .body(formatdoc! { "
+                    While installing packages, an error occurred while downloading {package}. \
+                    This may be due to an unstable network connection or an issue \
+                    with the upstream Debian package repository.
+
+                    Suggestions:
+                    - Check the status of {canonical_status_url} for any reported issues
+                " })
+                .debug_info(e.to_string())
+                .call()
+        }
+
+        InstallPackagesError::WritePackage(package, download_url, destination_path, e) => {
+            let package = style::value(package);
+            let download_url = style::url(download_url);
+            let destination_path = file_value(destination_path);
+            create_error()
+                .error_type(UserFacing(SuggestRetryBuild::Yes, SuggestSubmitIssue::Yes))
+                .header("Failed to download package")
+                .body(formatdoc! { "
+                    An unexpected I/O error occured while downloading {package} from {download_url} \
+                    to {destination_path}. This may be due to an unstable network connection or an issue \
+                    with the upstream Debian package repository.
+
+                    Suggestions:
+                    - Check the status of {canonical_status_url} for any reported issues
+                " })
+                .debug_info(e.to_string())
+                .call()
+        }
+
+        InstallPackagesError::ChecksumFailed {
+            url,
+            expected,
+            actual,
+        } => {
+            let url = style::url(url);
+            let expected = style::value(expected);
+            let actual = style::value(actual);
+            create_error()
+                .error_type(UserFacing(SuggestRetryBuild::Yes, SuggestSubmitIssue::No))
+                .header("Package checksum verification failed")
+                .body(formatdoc! { "
+                    An error occurred while verifying the checksum of the package at {url}. \
+                    This may be due to an issue with the upstream Debian package repository.
+
+                    Checksum:
+                    - Expected - {expected}
+                    - Actual - {actual}
+                " })
+                .call()
+        }
+
+        InstallPackagesError::OpenPackageArchive(file, e) => {
+            let file = file_value(file);
+            create_error()
+                .error_type(Internal)
+                .header("Failed to open package archive")
+                .body(formatdoc! {
+                    "An unexpected I/O error occurred while trying to open the archive at {file}."
+                })
+                .debug_info(e.to_string())
+                .call()
+        }
+
+        InstallPackagesError::OpenPackageArchiveEntry(file, e) => {
+            let file = file_value(file);
+            create_error()
+                .error_type(Internal)
+                .header("Failed to read package archive entry")
+                .body(formatdoc! {
+                    "An unexpected I/O error occurred while trying to read the entries of the \
+                    archive at {file}."
+                })
+                .debug_info(e.to_string())
+                .call()
+        }
+
+        InstallPackagesError::UnpackTarball(file, e) => {
+            let file = file_value(file);
+            create_error()
+                .error_type(Internal)
+                .header("Failed to unpack package archive")
+                .body(formatdoc! {
+                    "An unexpected I/O error occurred while trying to unpack the archive at {file}."
+                })
+                .debug_info(e.to_string())
+                .call()
+        }
+
+        InstallPackagesError::UnsupportedCompression(file, format) => {
+            let file = file_value(file);
+            let format = style::value(format);
+            create_error()
+                .error_type(Internal)
+                .header("Unsupported compression format for package archive")
+                .body(formatdoc! {
+                    "An unexpected compression format ({format}) was used for the package archive at {file}."
+                })
+                .call()
+        }
+
+        InstallPackagesError::ReadPackageConfig(file, e) => {
+            let file = file_value(file);
+            create_error()
+                .error_type(Internal)
+                .header("Failed to read package config file")
+                .body(formatdoc! {
+                    "An unexpected I/O error occurred while reading the package config file at {file}."
+                })
+                .debug_info(e.to_string())
+                .call()
+        }
+
+        InstallPackagesError::WritePackageConfig(file, e) => {
+            let file = file_value(file);
+            create_error()
+                .error_type(Internal)
+                .header("Failed to write package config file")
+                .body(formatdoc! {
+                    "An unexpected I/O error occurred while writing the package config file to {file}."
+                })
+                .debug_info(e.to_string())
+                .call()
+        }
+    }
+}
+
+fn on_framework_error(error: &Error<DebianPackagesBuildpackError>) -> ErrorMessage {
+    create_error()
+        .error_type(Framework)
+        .header("Heroku Deb Packages Buildpack internal error")
+        .body(formatdoc! {"
+            The framework used by this buildpack encountered an unexpected error.
+
+            If you can’t deploy to Heroku due to this issue, check the official Heroku Status page at \
+            status.heroku.com for any ongoing incidents. After all incidents resolve, retry your build.
+
+            Use the debug information above to troubleshoot and retry your build. If you think you found a \
+            bug in the buildpack, reproduce the issue locally with a minimal example and file an issue here:
+            https://github.com/heroku/buildpacks-debian-packages/issues/new
+        "})
+        .debug_info(error.to_string())
+        .call()
+}
+
+#[builder]
+fn create_error(
+    header: impl AsRef<str>,
+    body: impl AsRef<str>,
+    error_type: ErrorType,
+    debug_info: Option<String>,
+) -> ErrorMessage {
+    let mut message_parts = vec![
+        header.as_ref().trim().to_string(),
+        body.as_ref().trim().to_string(),
+    ];
+    let issues_url = style::url("https://github.com/heroku/buildpacks-debian-packages/issues/new");
+
+    match error_type {
+        Framework => {}
+        Internal => {
+            message_parts.push(formatdoc! { "
+                This error is almost always a buildpack bug. If you see this error, please file an \
+                issue here:
+                {issues_url}
+            "});
+        }
+        UserFacing(suggest_retry_build, suggest_submit_issue) => {
+            if let SuggestRetryBuild::Yes = suggest_retry_build {
+                message_parts.push(
+                    formatdoc! { "
+                    Use the debug information above to troubleshoot and retry your build.
+                "}
+                    .trim()
+                    .to_string(),
+                );
+            }
+
+            if let SuggestSubmitIssue::Yes = suggest_submit_issue {
+                message_parts.push(formatdoc! { "
+                    If the issue persists and you think you found a bug in the buildpack, reproduce \
+                    the issue locally with a minimal example. Open an issue in the buildpack's GitHub \
+                    repository and include the details here:
+                    {issues_url}
+                "}.trim().to_string());
+            }
+        }
+    }
+
+    let message = message_parts.join("\n\n");
+
+    ErrorMessage {
+        debug_info,
+        message,
+    }
+}
+
+fn print_error<W>(error_message: ErrorMessage, writer: W)
+where
+    W: Write + Send + Sync + 'static,
+{
+    let mut log = Print::new(writer).without_header();
+    if let Some(debug_info) = error_message.debug_info {
+        log = log
+            .bullet(style::important("Debug Info:"))
+            .sub_bullet(debug_info)
+            .done();
+    }
+    log.error(error_message.message);
+}
+
+fn file_value(value: impl AsRef<Path>) -> String {
+    style::value(value.as_ref().to_string_lossy())
+}
+
+fn get_canonical_status_url() -> String {
+    style::url("https://status.canonical.com/")
+}
+
+fn get_package_search_url() -> String {
+    style::url("https://packages.ubuntu.com/")
+}
+
+#[derive(Debug)]
+struct ErrorMessage {
+    debug_info: Option<String>,
+    message: String,
+}
+
+#[derive(Debug, PartialEq)]
+enum ErrorType {
+    Framework,
+    Internal,
+    UserFacing(SuggestRetryBuild, SuggestSubmitIssue),
+}
+
+#[derive(Debug, PartialEq)]
+enum SuggestRetryBuild {
+    Yes,
+    No,
+}
+
+#[derive(Debug, PartialEq)]
+enum SuggestSubmitIssue {
+    Yes,
+    No,
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -764,14 +764,22 @@ fn create_error(
         body.as_ref().trim().to_string(),
     ];
     let issues_url = style::url("https://github.com/heroku/buildpacks-debian-packages/issues/new");
+    let pack = style::value("pack");
+    let pack_url =
+        style::url("https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/");
 
     match error_type {
         Framework => {}
         Internal => {
             message_parts.push(formatdoc! { "
-                This error is almost always a buildpack bug. If you see this error, please file an \
-                issue here:
+                The causes for this error are unknown. We do not have suggestions for diagnosis or a \
+                workaround at this time. You can help our understanding by sharing your buildpack log \
+                and a description of the issue at:
                 {issues_url}
+                
+                If you're able to reproduce the problem with an example application and the {pack} \
+                build tool ({pack_url}), adding that information to the discussion will also help. Once \
+                we have more information around the causes of this error we may update this message.
             "});
         }
         UserFacing(suggest_retry_build, suggest_submit_issue) => {
@@ -1103,8 +1111,15 @@ mod tests {
                 ! - Ubuntu 24.04 (amd64, arm64)
                 ! - Ubuntu 22.04 (amd64)
                 !
-                ! This error is almost always a buildpack bug. If you see this error, please file an issue here:
+                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
+                a workaround at this time. You can help our understanding by sharing your buildpack log \
+                and a description of the issue at:
                 ! https://github.com/heroku/buildpacks-debian-packages/issues/new
+                !
+                ! If you're able to reproduce the problem with an example application and the `pack` \
+                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
+                adding that information to the discussion will also help. Once we have more information \
+                around the causes of this error we may update this message.
             "},
         );
     }
@@ -1125,8 +1140,15 @@ mod tests {
                 !
                 ! The distribution has no sources to update packages from.
                 !
-                ! This error is almost always a buildpack bug. If you see this error, please file an issue here:
+                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
+                a workaround at this time. You can help our understanding by sharing your buildpack log \
+                and a description of the issue at:
                 ! https://github.com/heroku/buildpacks-debian-packages/issues/new
+                !
+                ! If you're able to reproduce the problem with an example application and the `pack` \
+                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
+                adding that information to the discussion will also help. Once we have more information \
+                around the causes of this error we may update this message.
             "},
         );
     }
@@ -1153,8 +1175,15 @@ mod tests {
                         !
                         ! A background task responsible for updating sources failed to complete.
                         !
-                        ! This error is almost always a buildpack bug. If you see this error, please file an issue here:
+                        ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
+                        a workaround at this time. You can help our understanding by sharing your buildpack log \
+                        and a description of the issue at:
                         ! https://github.com/heroku/buildpacks-debian-packages/issues/new
+                        !
+                        ! If you're able to reproduce the problem with an example application and the `pack` \
+                        build tool \\(https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/\\), \
+                        adding that information to the discussion will also help. Once we have more information \
+                        around the causes of this error we may update this message.
                     "}
                 );
             },
@@ -1192,8 +1221,15 @@ mod tests {
                 !
                 ! You can find the invalid layer name in the debug information above.
                 !
-                ! This error is almost always a buildpack bug. If you see this error, please file an issue here:
+                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
+                a workaround at this time. You can help our understanding by sharing your buildpack log \
+                and a description of the issue at:
                 ! https://github.com/heroku/buildpacks-debian-packages/issues/new
+                !
+                ! If you're able to reproduce the problem with an example application and the `pack` \
+                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
+                adding that information to the discussion will also help. Once we have more information \
+                around the causes of this error we may update this message.
             "},
         );
     }
@@ -1299,8 +1335,15 @@ mod tests {
                 ! - Extract new certificates by running the ./scripts/extract_keys.sh script found \
                 in this buildpack's repository.
                 !
-                ! This error is almost always a buildpack bug. If you see this error, please file an issue here:
+                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
+                a workaround at this time. You can help our understanding by sharing your buildpack log \
+                and a description of the issue at:
                 ! https://github.com/heroku/buildpacks-debian-packages/issues/new
+                !
+                ! If you're able to reproduce the problem with an example application and the `pack` \
+                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
+                adding that information to the discussion will also help. Once we have more information \
+                around the causes of this error we may update this message.
             "},
         );
     }
@@ -1332,8 +1375,15 @@ mod tests {
                 ! - Verify if the keys changed by running the ./scripts/extract_keys.sh script \
                 found in this buildpack's repository.
                 !
-                ! This error is almost always a buildpack bug. If you see this error, please file an issue here:
+                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
+                a workaround at this time. You can help our understanding by sharing your buildpack log \
+                and a description of the issue at:
                 ! https://github.com/heroku/buildpacks-debian-packages/issues/new
+                !
+                ! If you're able to reproduce the problem with an example application and the `pack` \
+                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
+                adding that information to the discussion will also help. Once we have more information \
+                around the causes of this error we may update this message.
             "},
         );
     }
@@ -1361,8 +1411,15 @@ mod tests {
                 !
                 ! An unexpected I/O error occurred while writing release data to `/path/to/layer/file`.
                 !
-                ! This error is almost always a buildpack bug. If you see this error, please file an issue here:
+                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
+                a workaround at this time. You can help our understanding by sharing your buildpack log \
+                and a description of the issue at:
                 ! https://github.com/heroku/buildpacks-debian-packages/issues/new
+                !
+                ! If you're able to reproduce the problem with an example application and the `pack` \
+                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
+                adding that information to the discussion will also help. Once we have more information \
+                around the causes of this error we may update this message.
             "},
         );
     }
@@ -1390,8 +1447,15 @@ mod tests {
                 !
                 ! An unexpected I/O error occurred while reading Release data from `/path/to/layer/release-file`.
                 !
-                ! This error is almost always a buildpack bug. If you see this error, please file an issue here:
+                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
+                a workaround at this time. You can help our understanding by sharing your buildpack log \
+                and a description of the issue at:
                 ! https://github.com/heroku/buildpacks-debian-packages/issues/new
+                !
+                ! If you're able to reproduce the problem with an example application and the `pack` \
+                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
+                adding that information to the discussion will also help. Once we have more information \
+                around the causes of this error we may update this message.
             "},
         );
     }
@@ -1554,8 +1618,15 @@ mod tests {
                 !
                 ! An unexpected I/O error occurred while writing Package Index data to `/path/to/layer/package`.
                 !
-                ! This error is almost always a buildpack bug. If you see this error, please file an issue here:
+                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
+                a workaround at this time. You can help our understanding by sharing your buildpack log \
+                and a description of the issue at:
                 ! https://github.com/heroku/buildpacks-debian-packages/issues/new
+                !
+                ! If you're able to reproduce the problem with an example application and the `pack` \
+                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
+                adding that information to the discussion will also help. Once we have more information \
+                around the causes of this error we may update this message.
             "},
         );
     }
@@ -1649,8 +1720,15 @@ mod tests {
                 !
                 ! A background task responsible for reading Package Index data failed to complete.
                 !
-                ! This error is almost always a buildpack bug. If you see this error, please file an issue here:
+                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
+                a workaround at this time. You can help our understanding by sharing your buildpack log \
+                and a description of the issue at:
                 ! https://github.com/heroku/buildpacks-debian-packages/issues/new
+                !
+                ! If you're able to reproduce the problem with an example application and the `pack` \
+                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
+                adding that information to the discussion will also help. Once we have more information \
+                around the causes of this error we may update this message.
             "},
         );
     }
@@ -1679,8 +1757,15 @@ mod tests {
                 ! An unexpected I/O error occurred while reading Package Index data from \
                 `/path/to/layer/packages-file`.
                 !
-                ! This error is almost always a buildpack bug. If you see this error, please file an issue here:
+                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
+                a workaround at this time. You can help our understanding by sharing your buildpack log \
+                and a description of the issue at:
                 ! https://github.com/heroku/buildpacks-debian-packages/issues/new
+                !
+                ! If you're able to reproduce the problem with an example application and the `pack` \
+                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
+                adding that information to the discussion will also help. Once we have more information \
+                around the causes of this error we may update this message.
             "},
         );
     }
@@ -1722,8 +1807,15 @@ mod tests {
                 ! Suggestions:
                 ! - Run the build again with a clean cache.
                 !
-                ! This error is almost always a buildpack bug. If you see this error, please file an issue here:
+                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
+                a workaround at this time. You can help our understanding by sharing your buildpack log \
+                and a description of the issue at:
                 ! https://github.com/heroku/buildpacks-debian-packages/issues/new
+                !
+                ! If you're able to reproduce the problem with an example application and the `pack` \
+                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
+                adding that information to the discussion will also help. Once we have more information \
+                around the causes of this error we may update this message.
             "},
         );
     }
@@ -1752,8 +1844,15 @@ mod tests {
                 !
                 ! An unexpected I/O error occurred while reading system packages from `/var/lib/dpkg/status`.
                 !
-                ! This error is almost always a buildpack bug. If you see this error, please file an issue here:
+                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
+                a workaround at this time. You can help our understanding by sharing your buildpack log \
+                and a description of the issue at:
                 ! https://github.com/heroku/buildpacks-debian-packages/issues/new
+                !
+                ! If you're able to reproduce the problem with an example application and the `pack` \
+                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
+                adding that information to the discussion will also help. Once we have more information \
+                around the causes of this error we may update this message.
             "},
         );
     }
@@ -1785,8 +1884,15 @@ mod tests {
                 !
                 ! An unexpected parsing error occurred while reading system packages from `/var/lib/dpkg/status`.
                 !
-                ! This error is almost always a buildpack bug. If you see this error, please file an issue here:
+                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
+                a workaround at this time. You can help our understanding by sharing your buildpack log \
+                and a description of the issue at:
                 ! https://github.com/heroku/buildpacks-debian-packages/issues/new
+                !
+                ! If you're able to reproduce the problem with an example application and the `pack` \
+                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
+                adding that information to the discussion will also help. Once we have more information \
+                around the causes of this error we may update this message.
             "},
         );
     }
@@ -1879,8 +1985,15 @@ mod tests {
                     !
                     ! A background task responsible for installing failed to complete.
                     !
-                    ! This error is almost always a buildpack bug. If you see this error, please file an issue here:
+                    ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
+                    a workaround at this time. You can help our understanding by sharing your buildpack log \
+                    and a description of the issue at:
                     ! https://github.com/heroku/buildpacks-debian-packages/issues/new
+                    !
+                    ! If you're able to reproduce the problem with an example application and the `pack` \
+                    build tool \\(https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/\\), \
+                    adding that information to the discussion will also help. Once we have more information \
+                    around the causes of this error we may update this message.
                 "}
                 );
             },
@@ -1906,8 +2019,15 @@ mod tests {
                 ! The package information for `some-package` contains a Filename field of `..` which \
                 produces an invalid name to use as a download path.
                 !
-                ! This error is almost always a buildpack bug. If you see this error, please file an issue here:
+                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
+                a workaround at this time. You can help our understanding by sharing your buildpack log \
+                and a description of the issue at:
                 ! https://github.com/heroku/buildpacks-debian-packages/issues/new
+                !
+                ! If you're able to reproduce the problem with an example application and the `pack` \
+                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
+                adding that information to the discussion will also help. Once we have more information \
+                around the causes of this error we may update this message.
             "},
         );
     }
@@ -2039,8 +2159,15 @@ mod tests {
                 !
                 ! An unexpected I/O error occurred while trying to open the archive at `/path/to/layer/archive-file.tgz`.
                 !
-                ! This error is almost always a buildpack bug. If you see this error, please file an issue here:
+                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
+                a workaround at this time. You can help our understanding by sharing your buildpack log \
+                and a description of the issue at:
                 ! https://github.com/heroku/buildpacks-debian-packages/issues/new
+                !
+                ! If you're able to reproduce the problem with an example application and the `pack` \
+                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
+                adding that information to the discussion will also help. Once we have more information \
+                around the causes of this error we may update this message.
             "},
         );
     }
@@ -2069,8 +2196,15 @@ mod tests {
                 ! An unexpected I/O error occurred while trying to read the entries of the archive at \
                 `/path/to/layer/archive-file.tgz`.
                 !
-                ! This error is almost always a buildpack bug. If you see this error, please file an issue here:
+                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
+                a workaround at this time. You can help our understanding by sharing your buildpack log \
+                and a description of the issue at:
                 ! https://github.com/heroku/buildpacks-debian-packages/issues/new
+                !
+                ! If you're able to reproduce the problem with an example application and the `pack` \
+                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
+                adding that information to the discussion will also help. Once we have more information \
+                around the causes of this error we may update this message.
             "},
         );
     }
@@ -2098,8 +2232,15 @@ mod tests {
                 !
                 ! An unexpected I/O error occurred while trying to unpack the archive at `/path/to/layer/archive-file.tgz`.
                 !
-                ! This error is almost always a buildpack bug. If you see this error, please file an issue here:
+                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
+                a workaround at this time. You can help our understanding by sharing your buildpack log \
+                and a description of the issue at:
                 ! https://github.com/heroku/buildpacks-debian-packages/issues/new
+                !
+                ! If you're able to reproduce the problem with an example application and the `pack` \
+                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
+                adding that information to the discussion will also help. Once we have more information \
+                around the causes of this error we may update this message.
             "},
         );
     }
@@ -2124,8 +2265,15 @@ mod tests {
                 ! An unexpected compression format (`lz`) was used for the package archive at \
                 `/path/to/layer/archive-file.tgz`.
                 !
-                ! This error is almost always a buildpack bug. If you see this error, please file an issue here:
+                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
+                a workaround at this time. You can help our understanding by sharing your buildpack log \
+                and a description of the issue at:
                 ! https://github.com/heroku/buildpacks-debian-packages/issues/new
+                !
+                ! If you're able to reproduce the problem with an example application and the `pack` \
+                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
+                adding that information to the discussion will also help. Once we have more information \
+                around the causes of this error we may update this message.
             "},
         );
     }
@@ -2155,8 +2303,15 @@ mod tests {
                 ! An unexpected I/O error occurred while reading the package config file at \
                 `/path/to/layer/pkgconfig/somepackage.pc`.
                 !
-                ! This error is almost always a buildpack bug. If you see this error, please file an issue here:
+                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
+                a workaround at this time. You can help our understanding by sharing your buildpack log \
+                and a description of the issue at:
                 ! https://github.com/heroku/buildpacks-debian-packages/issues/new
+                !
+                ! If you're able to reproduce the problem with an example application and the `pack` \
+                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
+                adding that information to the discussion will also help. Once we have more information \
+                around the causes of this error we may update this message.
             "},
         );
     }
@@ -2186,8 +2341,15 @@ mod tests {
                 ! An unexpected I/O error occurred while writing the package config file to \
                 `/path/to/layer/pkgconfig/somepackage.pc`.
                 !
-                ! This error is almost always a buildpack bug. If you see this error, please file an issue here:
+                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
+                a workaround at this time. You can help our understanding by sharing your buildpack log \
+                and a description of the issue at:
                 ! https://github.com/heroku/buildpacks-debian-packages/issues/new
+                !
+                ! If you're able to reproduce the problem with an example application and the `pack` \
+                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
+                adding that information to the discussion will also help. Once we have more information \
+                around the causes of this error we may update this message.
             "},
         );
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -78,7 +78,7 @@ fn on_config_error(error: ConfigError) -> ErrorMessage {
             let toml_spec_url = style::url("https://toml.io/en/v1.0.0");
             let root_config_key = style::value("[com.heroku.buildpacks.debian-packages]");
             let configuration_doc_url =
-                style::url("https://github.com/heroku/buildpacks-debian-packages#configuration");
+                style::url("https://github.com/heroku/buildpacks-deb-packages#configuration");
             let debian_package_name_format_url = style::url(
                 "https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-source",
             );
@@ -932,8 +932,8 @@ mod tests {
                 Context
                 -------
                 We read the buildpack configuration from project.toml which must be a valid TOML file.
-                If the file is valid but the value supplied using the configuration key for this buildpack 
-                is not a TOML table then the configuration is incorrect and we can provide details to the 
+                If the file is valid but the value supplied using the configuration key for this buildpack
+                is not a TOML table then the configuration is incorrect and we can provide details to the
                 user on how they can fix this.
             ",
             ConfigError::ParseConfig(
@@ -949,7 +949,7 @@ mod tests {
                 !
                 ! Suggestions:
                 ! - See the buildpack documentation for the proper usage for this configuration at \
-                https://github.com/heroku/buildpacks-debian-packages#configuration
+                https://github.com/heroku/buildpacks-deb-packages#configuration
                 ! - See the TOML documentation for more details on the TOML table type at \
                 https://toml.io/en/v1.0.0
                 !
@@ -1000,9 +1000,9 @@ mod tests {
                 Context
                 -------
                 We read the buildpack configuration from project.toml which must be a valid TOML file.
-                If the file is valid but the value supplied using the configuration for this buildpack 
-                contains a package name that would be invalid according to Debian package naming policies, 
-                we report this package name to the user and ask them to verify it. 
+                If the file is valid but the value supplied using the configuration for this buildpack
+                contains a package name that would be invalid according to Debian package naming policies,
+                we report this package name to the user and ask them to verify it.
             ",
             ConfigError::ParseConfig(
                 "/path/to/project.toml".into(),
@@ -1038,7 +1038,7 @@ mod tests {
                 Context
                 -------
                 We read the buildpack configuration from project.toml which must be a valid TOML file.
-                If the file is valid but the value supplied using the configuration for this buildpack 
+                If the file is valid but the value supplied using the configuration for this buildpack
                 contains a package entry that is neither a string nor inline table value, it is invalid.
                 We report this to the user and request they check the buildpack documentation for proper
                 usage.
@@ -1067,7 +1067,7 @@ mod tests {
                 !
                 ! Suggestions:
                 ! - See the buildpack documentation for the proper usage for this configuration at \
-                https://github.com/heroku/buildpacks-debian-packages#configuration
+                https://github.com/heroku/buildpacks-deb-packages#configuration
                 ! - See the TOML documentation for more details on the TOML string and inline \
                 table types at https://toml.io/en/v1.0.0
                 !
@@ -1082,12 +1082,12 @@ mod tests {
                 Context
                 -------
                 This buildpack only supports the following distributions:
-                - Ubuntu 22.04 (amd64) 
-                - Ubuntu 24.04 (amd64, arm64) 
-                
+                - Ubuntu 22.04 (amd64)
+                - Ubuntu 24.04 (amd64, arm64)
+
                 Anything else is unsupported. This error is unlikely to be seen by an end-user but may
-                be helpful for developers hacking on this buildpack. Tools like pack also validate 
-                buildpacks against their target distribution metadata to prevent this exact scenario. 
+                be helpful for developers hacking on this buildpack. Tools like pack also validate
+                buildpacks against their target distribution metadata to prevent this exact scenario.
             ",
             UnsupportedDistro(UnsupportedDistroError {
                 name: "Windows".to_string(),
@@ -1116,7 +1116,7 @@ mod tests {
                 -------
                 This is a developer error. It should never be seen by an end-user but could occur if
                 the registered sources for a distribution were modified or someone forgot to register
-                ones for a specific architecture. Our testing processes should always catch this but, 
+                ones for a specific architecture. Our testing processes should always catch this but,
                 if not, we should direct users to file an issue.
             ",
             CreatePackageIndexError::NoSources,
@@ -1170,8 +1170,8 @@ mod tests {
                 This is a developer error. It should never be seen by an end-user. The only restrictions
                 on layer naming are that it can't be named 'build', 'launch', or 'cache' and it must be
                 a valid filename. The hexidecimal character set used here should be safe. If a bug is
-                introduced in how this name is generated then we report this and ask the user to file 
-                an issue against this buildpack. 
+                introduced in how this name is generated then we report this and ask the user to file
+                an issue against this buildpack.
             ",
             CreatePackageIndexError::InvalidLayerName(
                 "http://archive.ubuntu.com/ubuntu/dists/jammy/InRelease".to_string(),
@@ -1204,7 +1204,7 @@ mod tests {
             "
                 Context
                 -------
-                Package sources are requested from a Debian repository starting with a download of 
+                Package sources are requested from a Debian repository starting with a download of
                 the repository's release file. Network I/O can fail for any number of reasons but
                 the most likely here is that there is a problem with the upstream repository which
                 does have a status page we can direct the user to.
@@ -1239,7 +1239,7 @@ mod tests {
             "
                 Context
                 -------
-                Package sources are requested from a Debian repository starting with a download of 
+                Package sources are requested from a Debian repository starting with a download of
                 the repository's release file. This error happens after the request has been initiated
                 and we start reading the response body. Network I/O can fail for any number of reasons but
                 the most likely here is that there is a problem with the upstream repository which
@@ -1275,9 +1275,9 @@ mod tests {
             "
                 Context
                 -------
-                This is a developer error. It should never be seen by an end-user. We validate 
+                This is a developer error. It should never be seen by an end-user. We validate
                 release files using PGP certificates from the supported distributions and if there
-                is a problem with the certificate file, this error would happen. Our testing processes 
+                is a problem with the certificate file, this error would happen. Our testing processes
                 should always catch this but, if not, we should direct users to file an issue.
             ",
             CreatePackageIndexError::CreatePgpCertificate(anyhow!(
@@ -1311,10 +1311,10 @@ mod tests {
             "
                 Context
                 -------
-                This is a developer error. It should never be seen by an end-user. We validate 
+                This is a developer error. It should never be seen by an end-user. We validate
                 release files using PGP certificates from the supported distributions and if there
-                is a problem with how the release files are signed, this error would happen. Our 
-                testing processes should always catch this but, if not, we should direct users to file 
+                is a problem with how the release files are signed, this error would happen. Our
+                testing processes should always catch this but, if not, we should direct users to file
                 an issue.
             ",
             CreatePackageIndexError::CreatePgpVerifier(anyhow!("Malformed OpenPGP message")),
@@ -1344,7 +1344,7 @@ mod tests {
             "
                 Context
                 -------
-                We write downloaded release files and other information into the release layer. I/O 
+                We write downloaded release files and other information into the release layer. I/O
                 operations can fail for any number of reasons which we can't anticipate and since this
                 file-system area is managed by the buildpack process there is nothing the user can do
                 here other than report it.
@@ -1373,7 +1373,7 @@ mod tests {
             "
                 Context
                 -------
-                We read cached release files and other information from the release layer. I/O 
+                We read cached release files and other information from the release layer. I/O
                 operations can fail for any number of reasons which we can't anticipate and since this
                 file-system area is managed by the buildpack process there is nothing the user can do
                 here other than report it.
@@ -1402,9 +1402,9 @@ mod tests {
             "
                 Context
                 -------
-                If the release file cannot be parsed, this is either a developer error or a serious 
+                If the release file cannot be parsed, this is either a developer error or a serious
                 problem with the downloaded release file. Running the build with a clean cache
-                should force the file to be re-downloaded which may correct the issue. 
+                should force the file to be re-downloaded which may correct the issue.
             ",
             CreatePackageIndexError::ParseReleaseFile(
                 "/path/to/layer/release-file".into(),
@@ -1469,8 +1469,8 @@ mod tests {
             "
                 Context
                 -------
-                If the release file downloaded from the Debian repository is missing the package index 
-                entry for a component then there's a serious problem with the repository. 
+                If the release file downloaded from the Debian repository is missing the package index
+                entry for a component then there's a serious problem with the repository.
             ",
             CreatePackageIndexError::MissingPackageIndexReleaseHash(
                 RepositoryUri::from("http://archive.ubuntu.com/ubuntu/dists/jammy/InRelease"),
@@ -1539,7 +1539,7 @@ mod tests {
             "
                 Context
                 -------
-                When downloading a package index the response body stream is written directly to the 
+                When downloading a package index the response body stream is written directly to the
                 file-system. This error could happen if the file to write to could not be opened.
             ",
             CreatePackageIndexError::WritePackagesLayer(
@@ -1566,8 +1566,8 @@ mod tests {
             "
                 Context
                 -------
-                When downloading a package index the response body stream is written directly to the 
-                file-system. File and network I/O can fail for any number of reasons but the most 
+                When downloading a package index the response body stream is written directly to the
+                file-system. File and network I/O can fail for any number of reasons but the most
                 likely here would be a connection interruption.
             ",
             CreatePackageIndexError::WritePackageIndexFromResponse(
@@ -1603,7 +1603,7 @@ mod tests {
             "
                 Context
                 -------
-                All downloaded package indexes are verified according to the checksum given by the 
+                All downloaded package indexes are verified according to the checksum given by the
                 owning release file. If these checksums don't match then the download is invalid. When
                 this happens a rebuild typically fixes the issue.
             ",
@@ -1634,10 +1634,10 @@ mod tests {
             "
                 Context
                 -------
-                This is a developer error. It should never be seen by an end-user. Processing package 
-                index files is a CPU-intensive operation and happens in parallel worker tasks for 
+                This is a developer error. It should never be seen by an end-user. Processing package
+                index files is a CPU-intensive operation and happens in parallel worker tasks for
                 efficiency. This error can happen if a worker task panics and the error isn't handled.
-                Our testing processes should always catch this but, if not, we should direct users to file 
+                Our testing processes should always catch this but, if not, we should direct users to file
                 an issue.
             ",
             CreatePackageIndexError::CpuTaskFailed(create_recv_error()),
@@ -1661,7 +1661,7 @@ mod tests {
             "
                 Context
                 -------
-                This is a developer error. It should never be seen by an end-user. We read from 
+                This is a developer error. It should never be seen by an end-user. We read from
                 a package index file stored in the layer directory managed by the buildpack process.
                 I/O errors can happen for any number of reasons and there's nothing the user can
                 do here.
@@ -1692,9 +1692,9 @@ mod tests {
                 Context
                 -------
                 We need to parse all packages contained in a package index file. This error could happen
-                if the package index contained bad data which would indicate a problem with the 
-                upstream repository but it's more likely to be a bug with the buildpack. Running the 
-                build with a fresh cache would force the package index to be re-downloaded which 
+                if the package index contained bad data which would indicate a problem with the
+                upstream repository but it's more likely to be a bug with the buildpack. Running the
+                build with a fresh cache would force the package index to be re-downloaded which
                 might fix the issue.
             ",
             CreatePackageIndexError::ParsePackages(
@@ -1737,7 +1737,7 @@ mod tests {
                 This is a developer error. It should never be seen by an end-user. All system packages
                 are stored in /var/lib/dpkg/status. I/O errors can happen for any number of reasons
                 but the most likely here is that the file doesn't exist for some reason or the file
-                path was accidentally modified. Our testing processes should always catch this but, 
+                path was accidentally modified. Our testing processes should always catch this but,
                 if not, we should direct users to file an issue.
             ",
             DeterminePackagesToInstallError::ReadSystemPackages(
@@ -1766,7 +1766,7 @@ mod tests {
                 -------
                 This is a developer error. It should never be seen by an end-user. All system packages
                 are stored in /var/lib/dpkg/status and it's unlikely for this file to be malformed. More
-                likely is there is a bug with the parsing logic. Our testing processes should always catch 
+                likely is there is a bug with the parsing logic. Our testing processes should always catch
                 this but, if not, we should direct users to file an issue.
             ",
             DeterminePackagesToInstallError::ParseSystemPackage(
@@ -1799,7 +1799,7 @@ mod tests {
                 -------
                 We're installing a list of packages given by the user in the buildpack configuration.
                 It's possible to provide a valid name of a package that doesn't actually exist in the
-                Debian repositories used by the distribution. If this happens we direct the user to 
+                Debian repositories used by the distribution. If this happens we direct the user to
                 the package search site for Ubuntu to verify the package name.
             ",
             DeterminePackagesToInstallError::PackageNotFound("some-package".to_string()),
@@ -1827,8 +1827,8 @@ mod tests {
                 Context
                 -------
                 We're installing a list of packages given by the user in the buildpack configuration.
-                There is a special type of package name in a Debian repository that represents a 
-                'virtual package' which may be implemented by one or more actual packages. This error 
+                There is a special type of package name in a Debian repository that represents a
+                'virtual package' which may be implemented by one or more actual packages. This error
                 is shown when there is more than one provider because we can't automatically determine
                 which one should be used without the user's input.
             ",
@@ -1893,10 +1893,10 @@ mod tests {
             "
                 Context
                 -------
-                This is a developer error. It should never be seen by an end-user. Packages 
-                specify a Filename field that can be used to form a filename to download the 
+                This is a developer error. It should never be seen by an end-user. Packages
+                specify a Filename field that can be used to form a filename to download the
                 package to. This error can only happen if that Filename field contains a value
-                of '..' which is unlikely since that would cause serious problems for the upstream 
+                of '..' which is unlikely since that would cause serious problems for the upstream
                 repository.
             ",
             InstallPackagesError::InvalidFilename("some-package".to_string(), "..".to_string()),
@@ -1918,7 +1918,7 @@ mod tests {
             "
                 Context
                 -------
-                Packages are downloaded from a Debian repository. Network I/O can fail for any number 
+                Packages are downloaded from a Debian repository. Network I/O can fail for any number
                 of reasons but the most likely here would be a problem with the upstream.
             ",
             InstallPackagesError::RequestPackage(
@@ -1954,7 +1954,7 @@ mod tests {
             "
                 Context
                 -------
-                Packages downloaded from a Debian repository are written directly to disk. Network I/O 
+                Packages downloaded from a Debian repository are written directly to disk. Network I/O
                 can fail for any number of reasons but the most likely here would be a problem with the upstream.
             ",
             InstallPackagesError::WritePackage(
@@ -1992,7 +1992,7 @@ mod tests {
             "
                 Context
                 -------
-                Packages downloaded from a Debian repository are validated against a checksum given by 
+                Packages downloaded from a Debian repository are validated against a checksum given by
                 their owning package index. If this error happens then there was a problem with the
                 download. When this happens, running the build again typically fixes it.
             ",
@@ -2023,9 +2023,9 @@ mod tests {
             "
                 Context
                 -------
-                Packages downloaded from a Debian repository are stored as tarballs which need to be 
+                Packages downloaded from a Debian repository are stored as tarballs which need to be
                 opened for extraction. I/O can fail for any number of reasons but since the buildpack
-                process owns this content, there's nothing the user can do here. 
+                process owns this content, there's nothing the user can do here.
             ",
             InstallPackagesError::OpenPackageArchive(
                 "/path/to/layer/archive-file.tgz".into(),
@@ -2051,10 +2051,10 @@ mod tests {
             "
                 Context
                 -------
-                Packages downloaded from a Debian repository are stored as tarballs which stores file 
-                information in individual file entries which need to be read for extraction. I/O 
-                can fail for any number of reasons but since the buildpack process owns this content, 
-                there's nothing the user can do here. 
+                Packages downloaded from a Debian repository are stored as tarballs which stores file
+                information in individual file entries which need to be read for extraction. I/O
+                can fail for any number of reasons but since the buildpack process owns this content,
+                there's nothing the user can do here.
             ",
             InstallPackagesError::OpenPackageArchiveEntry(
                 "/path/to/layer/archive-file.tgz".into(),
@@ -2081,10 +2081,10 @@ mod tests {
             "
                 Context
                 -------
-                Packages downloaded from a Debian repository are stored as tarballs which need to be 
-                extracted. This is done by iterating through each archive entry and writing it's 
-                content out as a file to the file-system. I/O can fail for any number of reasons but 
-                since the buildpack process owns this content, there's nothing the user can do here. 
+                Packages downloaded from a Debian repository are stored as tarballs which need to be
+                extracted. This is done by iterating through each archive entry and writing it's
+                content out as a file to the file-system. I/O can fail for any number of reasons but
+                since the buildpack process owns this content, there's nothing the user can do here.
             ",
             InstallPackagesError::UnpackTarball(
                 "/path/to/layer/archive-file.tgz".into(),
@@ -2110,7 +2110,7 @@ mod tests {
             "
                 Context
                 -------
-                This is a developer error. It should not be seen by an end-user. Packages from a Debian 
+                This is a developer error. It should not be seen by an end-user. Packages from a Debian
                 repository can be stored using several different compression formats. Should we encounter
                 an unexpected one that we aren't handling then this is a buildpack bug.
             ",
@@ -2137,10 +2137,10 @@ mod tests {
                 Context
                 -------
                 After a package is extracted, we need to update any hardcoded references to it's standard
-                install location that might be referenced in any package-config (*.pc) files from the 
-                package to reflect the install location within the layer directory by reading these files. 
-                I/O can fail for any number of reasons but since the buildpack process owns this content, 
-                there's nothing  the user can do here. 
+                install location that might be referenced in any package-config (*.pc) files from the
+                package to reflect the install location within the layer directory by reading these files.
+                I/O can fail for any number of reasons but since the buildpack process owns this content,
+                there's nothing  the user can do here.
             ",
             InstallPackagesError::ReadPackageConfig(
                 "/path/to/layer/pkgconfig/somepackage.pc".into(),
@@ -2168,10 +2168,10 @@ mod tests {
                 Context
                 -------
                 After a package is extracted, we need to update any hardcoded references to it's standard
-                install location that might be referenced in any package-config (*.pc) files from the 
-                package to reflect the install location within the layer directory by writing these files. 
-                I/O can fail for any number of reasons but since the buildpack process owns this content, 
-                there's nothing  the user can do here. 
+                install location that might be referenced in any package-config (*.pc) files from the
+                package to reflect the install location within the layer directory by writing these files.
+                I/O can fail for any number of reasons but since the buildpack process owns this content,
+                there's nothing  the user can do here.
             ",
             InstallPackagesError::WritePackageConfig(
                 "/path/to/layer/pkgconfig/somepackage.pc".into(),
@@ -2199,7 +2199,7 @@ mod tests {
                 Context
                 -------
                 This message is for any framework errors caused by libcnb.rs and should be consistent
-                with how our other buildpacks report framework errors.  
+                with how our other buildpacks report framework errors.
             ",
             Error::CannotWriteBuildSbom(create_io_error("operation interrupted")),
             indoc! {"

--- a/src/install_packages.rs
+++ b/src/install_packages.rs
@@ -146,7 +146,7 @@ async fn download(
         .send()
         .await
         .and_then(|res| res.error_for_status().map_err(Reqwest))
-        .map_err(|e| RequestPackage(repository_package.name.clone(), e))?;
+        .map_err(|e| RequestPackage(repository_package.clone(), e))?;
 
     let mut hasher = Sha256::new();
 
@@ -154,7 +154,7 @@ async fn download(
         .await
         .map_err(|e| {
             WritePackage(
-                repository_package.name.clone(),
+                repository_package.clone(),
                 download_url.clone(),
                 download_path.clone(),
                 e,
@@ -176,7 +176,7 @@ async fn download(
 
     async_copy(&mut reader, &mut writer).await.map_err(|e| {
         WritePackage(
-            repository_package.name.clone(),
+            repository_package.clone(),
             download_url.clone(),
             download_path.clone(),
             e,
@@ -414,8 +414,8 @@ async fn rewrite_package_config(package_config: &Path, install_path: &Path) -> B
 pub(crate) enum InstallPackagesError {
     TaskFailed(JoinError),
     InvalidFilename(String, String),
-    RequestPackage(String, reqwest_middleware::Error),
-    WritePackage(String, String, PathBuf, std::io::Error),
+    RequestPackage(RepositoryPackage, reqwest_middleware::Error),
+    WritePackage(RepositoryPackage, String, PathBuf, std::io::Error),
     ChecksumFailed {
         url: String,
         expected: String,

--- a/src/install_packages.rs
+++ b/src/install_packages.rs
@@ -13,7 +13,6 @@ use futures::io::AllowStdIo;
 use futures::TryStreamExt;
 use indexmap::IndexSet;
 use libcnb::build::BuildContext;
-use libcnb::data::layer::LayerNameError;
 use libcnb::data::layer_name;
 use libcnb::layer::{
     CachedLayerDefinition, InvalidMetadataAction, LayerState, RestoredLayerAction,
@@ -33,20 +32,18 @@ use walkdir::{DirEntry, WalkDir};
 
 use crate::debian::{Distro, MultiarchName, RepositoryPackage};
 use crate::install_packages::InstallPackagesError::{
-    ChecksumFailed, CreateLayer, DownloadPackage, NoFilename, OpenPackageArchive,
-    OpenPackageArchiveEntry, ReadPackageConfig, TaskFailed, UnpackTarball, UnsupportedCompression,
-    WriteLayerEnv, WriteLayerMetadata, WritePackage, WritePackageConfig,
+    ChecksumFailed, InvalidFilename, OpenPackageArchive, OpenPackageArchiveEntry,
+    ReadPackageConfig, RequestPackage, TaskFailed, UnpackTarball, UnsupportedCompression,
+    WritePackage, WritePackageConfig,
 };
-use crate::{DebianPackagesBuildpack, DebianPackagesBuildpackError};
-
-type Result<T> = std::result::Result<T, InstallPackagesError>;
+use crate::{BuildpackResult, DebianPackagesBuildpack, DebianPackagesBuildpackError};
 
 pub(crate) async fn install_packages(
     context: &Arc<BuildContext<DebianPackagesBuildpack>>,
     client: &ClientWithMiddleware,
     distro: &Distro,
     packages_to_install: Vec<RepositoryPackage>,
-) -> Result<()> {
+) -> BuildpackResult<()> {
     println!("## Installing packages");
     println!();
 
@@ -58,23 +55,21 @@ pub(crate) async fn install_packages(
         distro: distro.clone(),
     };
 
-    let install_layer = context
-        .cached_layer(
-            layer_name!("packages"),
-            CachedLayerDefinition {
-                build: true,
-                launch: true,
-                invalid_metadata_action: &|_| InvalidMetadataAction::DeleteLayer,
-                restored_layer_action: &|old_metadata: &InstallationMetadata, _| {
-                    if old_metadata == &new_metadata {
-                        RestoredLayerAction::KeepLayer
-                    } else {
-                        RestoredLayerAction::DeleteLayer
-                    }
-                },
+    let install_layer = context.cached_layer(
+        layer_name!("packages"),
+        CachedLayerDefinition {
+            build: true,
+            launch: true,
+            invalid_metadata_action: &|_| InvalidMetadataAction::DeleteLayer,
+            restored_layer_action: &|old_metadata: &InstallationMetadata, _| {
+                if old_metadata == &new_metadata {
+                    RestoredLayerAction::KeepLayer
+                } else {
+                    RestoredLayerAction::DeleteLayer
+                }
             },
-        )
-        .map_err(|e| CreateLayer(Box::new(e)))?;
+        },
+    )?;
 
     match install_layer.state {
         LayerState::Restored { .. } => {
@@ -83,9 +78,7 @@ pub(crate) async fn install_packages(
             }
         }
         LayerState::Empty { .. } => {
-            install_layer
-                .write_metadata(new_metadata)
-                .map_err(|e| WriteLayerMetadata(Box::new(e)))?;
+            install_layer.write_metadata(new_metadata)?;
 
             let mut download_and_extract_handles = JoinSet::new();
 
@@ -110,9 +103,7 @@ pub(crate) async fn install_packages(
         &MultiarchName::from(&distro.architecture),
     );
 
-    install_layer
-        .write_env(layer_env)
-        .map_err(|e| WriteLayerEnv(Box::new(e)))?;
+    install_layer.write_env(layer_env)?;
 
     rewrite_package_configs(&install_layer.path()).await?;
 
@@ -124,7 +115,7 @@ async fn download_and_extract(
     client: ClientWithMiddleware,
     repository_package: RepositoryPackage,
     install_dir: PathBuf,
-) -> Result<()> {
+) -> BuildpackResult<()> {
     println!("  Downloading and extracting {}", repository_package.name);
     let download_path = download(client, &repository_package).await?;
     extract(download_path, install_dir).await
@@ -133,7 +124,7 @@ async fn download_and_extract(
 async fn download(
     client: ClientWithMiddleware,
     repository_package: &RepositoryPackage,
-) -> Result<PathBuf> {
+) -> BuildpackResult<PathBuf> {
     let download_url = format!(
         "{}/{}",
         repository_package.repository_uri.as_str(),
@@ -143,7 +134,10 @@ async fn download(
     let download_file_name = PathBuf::from(repository_package.filename.as_str())
         .file_name()
         .map(ToOwned::to_owned)
-        .ok_or(NoFilename)?;
+        .ok_or(InvalidFilename(
+            repository_package.name.clone(),
+            repository_package.filename.clone(),
+        ))?;
 
     let download_path = temp_dir().join::<&Path>(download_file_name.as_ref());
 
@@ -152,13 +146,20 @@ async fn download(
         .send()
         .await
         .and_then(|res| res.error_for_status().map_err(Reqwest))
-        .map_err(DownloadPackage)?;
+        .map_err(|e| RequestPackage(repository_package.name.clone(), e))?;
 
     let mut hasher = Sha256::new();
 
     let mut writer = AsyncFile::create(&download_path)
         .await
-        .map_err(WritePackage)
+        .map_err(|e| {
+            WritePackage(
+                repository_package.name.clone(),
+                download_url.clone(),
+                download_path.clone(),
+                e,
+            )
+        })
         .map(AsyncBufWriter::new)?;
 
     // the inspect reader lets us pipe the response to both the output file and the hash digest
@@ -173,32 +174,38 @@ async fn download(
         |bytes| hasher.update(bytes),
     ));
 
-    async_copy(&mut reader, &mut writer)
-        .await
-        .map_err(WritePackage)?;
+    async_copy(&mut reader, &mut writer).await.map_err(|e| {
+        WritePackage(
+            repository_package.name.clone(),
+            download_url.clone(),
+            download_path.clone(),
+            e,
+        )
+    })?;
 
     let calculated_hash = format!("{:x}", hasher.finalize());
+    let hash = repository_package.sha256sum.to_string();
 
-    if repository_package.sha256sum != calculated_hash {
-        Err(ChecksumFailed(
-            download_url,
-            repository_package.sha256sum.to_string(),
-            calculated_hash,
-        ))?;
+    if hash != calculated_hash {
+        Err(ChecksumFailed {
+            url: download_url,
+            expected: hash,
+            actual: calculated_hash,
+        })?;
     }
 
     Ok(download_path)
 }
 
-async fn extract(download_path: PathBuf, output_dir: PathBuf) -> Result<()> {
+async fn extract(download_path: PathBuf, output_dir: PathBuf) -> BuildpackResult<()> {
     // a .deb file is an ar archive
     // https://manpages.ubuntu.com/manpages/jammy/en/man5/deb.5.html
-    let mut debian_archive = File::open(download_path)
-        .map_err(OpenPackageArchive)
+    let mut debian_archive = File::open(&download_path)
+        .map_err(|e| OpenPackageArchive(download_path.clone(), e))
         .map(ArArchive::new)?;
 
     while let Some(entry) = debian_archive.next_entry() {
-        let entry = entry.map_err(OpenPackageArchiveEntry)?;
+        let entry = entry.map_err(|e| OpenPackageArchiveEntry(download_path.clone(), e))?;
         let entry_path = PathBuf::from(OsString::from_vec(entry.header().identifier().to_vec()));
         let entry_reader =
             AsyncBufReader::new(FuturesAsyncReadCompatExt::compat(AllowStdIo::new(entry)));
@@ -213,24 +220,27 @@ async fn extract(download_path: PathBuf, output_dir: PathBuf) -> Result<()> {
                 tar_archive
                     .unpack(&output_dir)
                     .await
-                    .map_err(UnpackTarball)?;
+                    .map_err(|e| UnpackTarball(download_path.clone(), e))?;
             }
             (Some("data.tar"), Some("zstd" | "zst")) => {
                 let mut tar_archive = TarArchive::new(ZstdDecoder::new(entry_reader));
                 tar_archive
                     .unpack(&output_dir)
                     .await
-                    .map_err(UnpackTarball)?;
+                    .map_err(|e| UnpackTarball(download_path.clone(), e))?;
             }
             (Some("data.tar"), Some("xz")) => {
                 let mut tar_archive = TarArchive::new(XzDecoder::new(entry_reader));
                 tar_archive
                     .unpack(&output_dir)
                     .await
-                    .map_err(UnpackTarball)?;
+                    .map_err(|e| UnpackTarball(download_path.clone(), e))?;
             }
             (Some("data.tar"), Some(compression)) => {
-                Err(UnsupportedCompression(compression.to_string()))?;
+                Err(UnsupportedCompression(
+                    download_path.clone(),
+                    compression.to_string(),
+                ))?;
             }
             _ => {
                 // ignore other potential file entries (e.g.; debian-binary, control.tar)
@@ -352,7 +362,7 @@ where
     );
 }
 
-async fn rewrite_package_configs(install_path: &Path) -> Result<()> {
+async fn rewrite_package_configs(install_path: &Path) -> BuildpackResult<()> {
     let package_configs = WalkDir::new(install_path)
         .into_iter()
         .flatten()
@@ -373,10 +383,10 @@ fn is_package_config(entry: &DirEntry) -> bool {
     ), (Some(parent), Some(ext)) if parent == "pkgconfig" && ext == "pc")
 }
 
-async fn rewrite_package_config(package_config: &Path, install_path: &Path) -> Result<()> {
+async fn rewrite_package_config(package_config: &Path, install_path: &Path) -> BuildpackResult<()> {
     let contents = async_read_to_string(package_config)
         .await
-        .map_err(ReadPackageConfig)?;
+        .map_err(|e| ReadPackageConfig(package_config.to_path_buf(), e))?;
 
     let new_contents = contents
         .lines()
@@ -395,30 +405,34 @@ async fn rewrite_package_config(package_config: &Path, install_path: &Path) -> R
         .collect::<Vec<_>>()
         .join("\n");
 
-    async_write(package_config, new_contents)
+    Ok(async_write(package_config, new_contents)
         .await
-        .map_err(WritePackageConfig)
+        .map_err(|e| WritePackageConfig(package_config.to_path_buf(), e))?)
 }
 
 #[derive(Debug)]
-#[allow(dead_code)]
 pub(crate) enum InstallPackagesError {
     TaskFailed(JoinError),
-    InvalidLayerName(LayerNameError),
-    NoFilename,
-    CreateLayer(Box<libcnb::Error<DebianPackagesBuildpackError>>),
-    DownloadPackage(reqwest_middleware::Error),
-    WritePackage(std::io::Error),
-    ChecksumFailed(String, String, String),
-    OpenPackageArchive(std::io::Error),
-    OpenPackageArchiveEntry(std::io::Error),
-    UnpackTarball(std::io::Error),
-    WriteLayerMetadata(Box<libcnb::Error<DebianPackagesBuildpackError>>),
-    WriteLayerEnv(Box<libcnb::Error<DebianPackagesBuildpackError>>),
-    UnsupportedCompression(String),
-    ReadPackageConfig(std::io::Error),
-    WritePackageConfig(std::io::Error),
-    ConfigurePaths(std::io::Error),
+    InvalidFilename(String, String),
+    RequestPackage(String, reqwest_middleware::Error),
+    WritePackage(String, String, PathBuf, std::io::Error),
+    ChecksumFailed {
+        url: String,
+        expected: String,
+        actual: String,
+    },
+    OpenPackageArchive(PathBuf, std::io::Error),
+    OpenPackageArchiveEntry(PathBuf, std::io::Error),
+    UnpackTarball(PathBuf, std::io::Error),
+    UnsupportedCompression(PathBuf, String),
+    ReadPackageConfig(PathBuf, std::io::Error),
+    WritePackageConfig(PathBuf, std::io::Error),
+}
+
+impl From<InstallPackagesError> for libcnb::Error<DebianPackagesBuildpackError> {
+    fn from(value: InstallPackagesError) -> Self {
+        Self::BuildpackError(DebianPackagesBuildpackError::InstallPackages(value))
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]


### PR DESCRIPTION
The bulk of this PR is the error messages found in [errors.rs](https://github.com/heroku/buildpacks-debian-packages/compare/error_handling?expand=1#diff-6ff19a1ff611f3835b5a025663cf4dec901ed914626f78847414836439bd1a79). All other changes are modifications to the existing error structs and enums to pass through relevant data such as file paths on I/O errors, etc.

One interesting thing to note is that the error message builder used here allows for clearly marking certain types of errors as:
- `Framework` - for libcnb framework errors
- `Internal` - for unexpected errors such as I/O errors and other issues where we the issue is unlikely to be the fault of the user but where a developer using this buildpack might benefit from a more detailed message
- `UserFacing` - for errors that are due to things like misconfigurations, networking issues, etc. which provide information + actions that a user can take

---

## Related PRs:

- [x] #48 