### PR TITLE
Fix docker repository url

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.10"
 
 [buildpack]
 id = "heroku/deb-packages"
-version = "0.0.1"
+version = "0.0.0"
 name = "Heroku .deb Packages Buildpack"
 description = "Heroku's buildpack for installing .deb system packages."
 homepage = "https://github.com/heroku/buildpacks-deb-packages"

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -27,4 +27,4 @@ distros = [
 ]
 
 [metadata.release]
-image = { repository = "docker.io/heroku/buildpacks-deb-packages" }
+image = { repository = "docker.io/heroku/buildpack-deb-packages" }


### PR DESCRIPTION
All our docker buildpack urls are prefixed with `heroku/buildpack-`, not `heroku/buildpacks-`.