### PR TITLE
Update buildpack name/keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated the buildpack display name and keywords to be more consistent with our other CNBs. ([#59](https://github.com/heroku/buildpacks-deb-packages/pull/59))
+
 ## [0.0.1] - 2024-10-10
 
-* Initial release
+### Added
+
+- Initial release.
 
 [unreleased]: https://github.com/heroku/buildpacks-deb-packages/compare/v0.0.1...HEAD
 [0.0.1]: https://github.com/heroku/buildpacks-deb-packages/releases/tag/v0.0.1

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,10 +3,10 @@ api = "0.10"
 [buildpack]
 id = "heroku/deb-packages"
 version = "0.0.1"
-name = "Heroku .deb Packages Buildpack"
+name = "Heroku .deb Packages"
 description = "Heroku's buildpack for installing .deb system packages."
 homepage = "https://github.com/heroku/buildpacks-deb-packages"
-keywords = ["deb", "debian", "packages"]
+keywords = ["deb", "debian", "packages", "apt", "heroku"]
 
 [[buildpack.licenses]]
 type = "Apache-2.0"

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -58,7 +58,7 @@ fn test_failed_detection_when_project_file_has_no_config() {
 #[allow(clippy::too_many_lines)]
 fn test_general_usage_output() {
     integration_test("fixtures/general_usage", |ctx| {
-        assert_contains_match!(ctx.pack_stdout, r"# Heroku .deb Packages Buildpack \(v\d+\.\d+\.\d+\)");
+        assert_contains_match!(ctx.pack_stdout, r"# Heroku .deb Packages \(v\d+\.\d+\.\d+\)");
 
         match (get_integration_test_builder().as_str(), get_integration_test_arch().as_str()) {
             ("heroku/builder:22", "amd64") => {
@@ -224,7 +224,7 @@ fn test_general_usage_output_on_rebuild() {
     integration_test("fixtures/general_usage", |ctx| {
         let config = ctx.config.clone();
         ctx.rebuild(config, |ctx| {
-            assert_contains_match!(ctx.pack_stdout, r"# Heroku .deb Packages Buildpack \(v\d+\.\d+\.\d+\)");
+            assert_contains_match!(ctx.pack_stdout, r"# Heroku .deb Packages \(v\d+\.\d+\.\d+\)");
 
             match (get_integration_test_builder().as_str(), get_integration_test_arch().as_str()) {
                 ("heroku/builder:22", "amd64") => {


### PR DESCRIPTION
To make the name consistent with our other CNBs, eg:
https://github.com/heroku/buildpacks-python/blob/ee25c70c647a2d5d11b19bfc2a4bc1ab5598138c/buildpack.toml#L6
https://github.com/heroku/buildpacks-nodejs/blob/df5f1de2e6fde1ef98701740f80bf83b2975bedd/meta-buildpacks/nodejs/buildpack.toml#L6

And also to add some additional keywords.

See also:
https://github.com/heroku/cnb-builder-images/issues/408