### PR TITLE
Update buildpack output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated the buildpack display name and keywords to be more consistent with our other CNBs. ([#59](https://github.com/heroku/buildpacks-deb-packages/pull/59))
+- Updated the buildpack display name and keywords to be more consistent with our other
+  CNBs. ([#59](https://github.com/heroku/buildpacks-deb-packages/pull/59))
+- Modified the buildpack output format to align with our other
+  CNBs. ([#60](https://github.com/heroku/buildpacks-deb-packages/pull/60))
 
 ## [0.0.1] - 2024-10-10
 
@@ -18,4 +21,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release.
 
 [unreleased]: https://github.com/heroku/buildpacks-deb-packages/compare/v0.0.1...HEAD
+
 [0.0.1]: https://github.com/heroku/buildpacks-deb-packages/releases/tag/v0.0.1

--- a/README.md
+++ b/README.md
@@ -45,11 +45,13 @@ docker run --rm -it my-app
 
 ## Configuration
 
+### `project.toml`
+
 The configuration for this buildpack must be added to the project descriptor file (`project.toml`) at the root of your
 project using the `com.heroku.buildpacks.deb-packages` table. The list of packages to install must be
 specified there. See below for the [configuration schema](#schema) and an [example](#example).
 
-### Example
+#### Example
 
 ```toml
 # _.schema-version is required for the project descriptor
@@ -66,7 +68,7 @@ install = [
 ]
 ```
 
-### Schema
+#### Schema
 
 - `com.heroku.buildpacks.deb-packages` *__([table][toml-table], optional)__*
 
@@ -110,6 +112,14 @@ install = [
 >
 > If your Aptfile contains a package name that uses wildcards (e.g.; `mysql-*`) this must be replaced with the full list
 > of matching package names.
+
+### Environment Variables
+
+The following environment variables can be passed to the buildpack:
+
+| Name           | Value               | Default | Description                                                                                        |
+|----------------|---------------------|---------|----------------------------------------------------------------------------------------------------|
+| `BP_LOG_LEVEL` | `INFO`,<br> `DEBUG` | `INFO`  | Configures the verbosity of buildpack output. The `DEBUG` level is a superset of the `INFO` level. |
 
 ## How it works
 

--- a/src/debian/repository_package.rs
+++ b/src/debian/repository_package.rs
@@ -4,7 +4,7 @@ use rayon::iter::{IntoParallelIterator, ParallelBridge, ParallelIterator};
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Display, Formatter};
 
-#[derive(Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone, Hash)]
 pub(crate) struct RepositoryPackage {
     pub(crate) repository_uri: RepositoryUri,
     pub(crate) name: String,

--- a/src/debian/repository_uri.rs
+++ b/src/debian/repository_uri.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub(crate) struct RepositoryUri(String);
 
 impl RepositoryUri {

--- a/src/determine_packages_to_install.rs
+++ b/src/determine_packages_to_install.rs
@@ -4,8 +4,8 @@ use crate::{BuildpackResult, DebianPackagesBuildpackError};
 use apt_parser::Control;
 use bullet_stream::state::Bullet;
 use bullet_stream::{style, Print};
-use indexmap::{IndexMap, IndexSet};
-use std::collections::{HashMap, HashSet};
+use indexmap::IndexSet;
+use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
 use std::fs::read_to_string;
 use std::io::Stdout;
@@ -35,51 +35,45 @@ pub(crate) fn determine_packages_to_install(
                         e,
                     )
                 })
-                .map(|control| (control.package.to_string(), control))
+                .map(SystemPackage::from)
         })
-        .collect::<Result<HashMap<_, _>, _>>()?;
+        .collect::<Result<IndexSet<_>, _>>()?;
     log = sub_bullet.done();
 
-    let mut system_install_details = IndexMap::new();
-    let mut warnings = Vec::new();
+    let mut packages_marked_for_install = IndexSet::new();
+
     for requested_package in requested_packages {
-        let mut install_log = log.bullet(format!(
+        let mut notification_log = log.bullet(format!(
             "Determining install requirements for requested package {package}",
             package = style::value(requested_package.name.as_str())
         ));
         let mut visit_stack = IndexSet::new();
-        let mut package_install_details = IndexMap::new();
+        let mut package_notifications = IndexSet::new();
 
         visit(
             requested_package.name.as_str(),
             requested_package.skip_dependencies,
-            &mut visit_stack,
-            &mut package_install_details,
-            &system_install_details,
-            &mut warnings,
             &system_packages,
             package_index,
+            &mut packages_marked_for_install,
+            &mut visit_stack,
+            &mut package_notifications,
         )?;
 
-        if package_install_details.is_empty() {
-            install_log = install_log.sub_bullet("Nothing to add");
+        if package_notifications.is_empty() {
+            notification_log = notification_log.sub_bullet("Nothing to add");
         } else {
-            for (name, install_record) in package_install_details {
-                install_log = install_log.sub_bullet(install_record.to_string());
-                system_install_details.insert(name, install_record);
+            for package_notification in package_notifications {
+                notification_log = notification_log.sub_bullet(package_notification.to_string());
             }
         }
 
-        log = install_log.done();
+        log = notification_log.done();
     }
 
-    for warning in warnings {
-        log = log.warning(warning.to_string());
-    }
-
-    let packages_to_install = system_install_details
+    let packages_to_install = packages_marked_for_install
         .into_iter()
-        .map(|(_, install_record)| install_record.repository_package)
+        .map(|package_marked_for_install| package_marked_for_install.repository_package)
         .collect();
 
     Ok((packages_to_install, log))
@@ -105,94 +99,81 @@ pub(crate) fn determine_packages_to_install(
 //       The dependency solving done here is mostly for convenience. Any transitive packages added
 //       will be reported to the user and, if they aren't correct, the user may disable this dependency
 //       resolution on a per-package basis and specify a more appropriate set of packages.
-#[allow(clippy::too_many_arguments)]
 fn visit(
     package: &str,
     skip_dependencies: bool,
-    visit_stack: &mut IndexSet<String>,
-    package_install_details: &mut IndexMap<String, InstallRecord>,
-    system_install_details: &IndexMap<String, InstallRecord>,
-    warnings: &mut Vec<DependencyWarning>,
-    system_packages: &HashMap<String, Control>,
+    system_packages: &IndexSet<SystemPackage>,
     package_index: &PackageIndex,
+    packages_marked_for_install: &mut IndexSet<PackageMarkedForInstall>,
+    visit_stack: &mut IndexSet<String>,
+    package_notifications: &mut IndexSet<PackageNotification>,
 ) -> BuildpackResult<()> {
-    // check if this package is already on the system
-    if let Some(system_package) = system_packages.get(package) {
-        // only show this message if the package is a top-level dependency
-        if visit_stack.is_empty() {
-            warnings.push(DependencyWarning::AlreadyInstalledOnSystem {
-                requested_package: package.to_string(),
-                system_package_name: system_package.package.clone(),
-                system_package_version: system_package.version.clone(),
-            });
-        }
+    if let Some(system_package) = find_system_package_by_name(package, system_packages) {
+        package_notifications.insert(PackageNotification::AlreadyInstalledOnSystem {
+            system_package_name: system_package.package_name.clone(),
+            system_package_version: system_package.package_version.clone(),
+        });
         return Ok(());
     }
 
-    // check if the package is already marked to be installed on the system
-    if let Some(install_record) = system_install_details.get(package) {
-        // only show this message if the package is a top-level dependency
-        if visit_stack.is_empty() {
-            warnings.push(DependencyWarning::AlreadyInstalledByOtherPackage {
-                requested_package: package.to_string(),
-                installed_package: install_record.repository_package.clone(),
-                installed_by: install_record
-                    .dependency_path
-                    .first()
-                    .expect("The dependency path should always have at least 1 item")
-                    .clone(),
-            });
-        }
+    if let Some(package_marked_for_install) =
+        find_package_marked_for_install_by_name(package, packages_marked_for_install)
+    {
+        package_notifications.insert(PackageNotification::AlreadyInstalledByOtherPackage {
+            installed_package: package_marked_for_install.repository_package.clone(),
+            installed_by: package_marked_for_install.requested_by.clone(),
+        });
         return Ok(());
     }
 
-    if let Some(package) = package_index.get_highest_available_version(package) {
-        package_install_details.insert(
-            package.name.to_string(),
-            InstallRecord {
-                repository_package: package.clone(),
-                dependency_path: visit_stack.iter().cloned().collect(),
-            },
-        );
+    if let Some(repository_package) = package_index.get_highest_available_version(package) {
+        packages_marked_for_install.insert(PackageMarkedForInstall {
+            repository_package: repository_package.clone(),
+            requested_by: visit_stack.first().cloned().unwrap_or(package.to_string()),
+        });
 
-        visit_stack.insert(package.name.to_string());
+        package_notifications.insert(PackageNotification::Added {
+            repository_package: repository_package.clone(),
+            dependency_path: visit_stack.iter().cloned().collect(),
+        });
+
+        visit_stack.insert(repository_package.name.to_string());
 
         if !skip_dependencies {
-            for dependency in package.get_dependencies() {
-                // Don't bother looking at any dependencies we've already seen or that are already
-                // on the system because it'll just cause a bunch of noisy output. We only want
-                // output details about requested packages and any transitive dependencies added.
-                let already_processed = system_packages.contains_key(dependency)
-                    || package_install_details.contains_key(dependency);
-                if !already_processed {
+            for dependency in repository_package.get_dependencies() {
+                if should_visit_dependency(dependency, system_packages, packages_marked_for_install)
+                {
                     visit(
                         dependency,
                         skip_dependencies,
-                        visit_stack,
-                        package_install_details,
-                        system_install_details,
-                        warnings,
                         system_packages,
                         package_index,
+                        packages_marked_for_install,
+                        visit_stack,
+                        package_notifications,
                     )?;
                 }
             }
         }
 
-        visit_stack.shift_remove(&package.name);
+        visit_stack.shift_remove(&repository_package.name);
     } else {
         let virtual_package_provider =
-            get_provider_for_virtual_package(package, package_index, visit_stack, warnings)?;
+            get_provider_for_virtual_package(package, package_index, package_notifications)?;
+
+        visit_stack.insert(package.to_string());
+
         visit(
             virtual_package_provider.name.as_str(),
             skip_dependencies,
-            visit_stack,
-            package_install_details,
-            system_install_details,
-            warnings,
             system_packages,
             package_index,
+            packages_marked_for_install,
+            visit_stack,
+            package_notifications,
         )?;
+
+        visit_stack.shift_remove(package);
     }
 
     Ok(())
@@ -201,27 +182,23 @@ fn visit(
 fn get_provider_for_virtual_package<'a>(
     package: &str,
     package_index: &'a PackageIndex,
-    visit_stack: &IndexSet<String>,
-    warnings: &mut Vec<DependencyWarning>,
+    package_install_details: &mut IndexSet<PackageNotification>,
 ) -> BuildpackResult<&'a RepositoryPackage> {
     let providers = package_index.get_providers(package);
     Ok(match providers.iter().collect::<Vec<_>>().as_slice() {
-        [providing_package] => {
-            package_index
-                .get_highest_available_version(providing_package)
-                .inspect(|repository_package| {
-                    // only show this message if the package is a top-level dependency
-                    if visit_stack.is_empty() {
-                        warnings.push(DependencyWarning::VirtualPackageHasOnlyOneImplementor {
-                            requested_package: package.to_string(),
-                            implementor: (*repository_package).clone(),
-                        });
-                    }
-                })
-                .ok_or(DeterminePackagesToInstallError::PackageNotFound(
-                    package.to_string(),
-                ))
-        }
+        [providing_package] => package_index
+            .get_highest_available_version(providing_package)
+            .inspect(|repository_package| {
+                package_install_details.insert(
+                    PackageNotification::VirtualPackageHasOnlyOneImplementor {
+                        requested_package: package.to_string(),
+                        implementor: (*repository_package).clone(),
+                    },
+                );
+            })
+            .ok_or(DeterminePackagesToInstallError::PackageNotFound(
+                package.to_string(),
+            )),
         [] => Err(DeterminePackagesToInstallError::PackageNotFound(
             package.to_string(),
         )),
@@ -235,6 +212,43 @@ fn get_provider_for_virtual_package<'a>(
             ),
         ),
     }?)
+}
+
+fn find_system_package_by_name<'a>(
+    package_name: &str,
+    system_packages: &'a IndexSet<SystemPackage>,
+) -> Option<&'a SystemPackage> {
+    system_packages
+        .iter()
+        .find(|system_package| system_package.package_name == package_name)
+}
+
+fn find_package_marked_for_install_by_name<'a>(
+    package_name: &str,
+    packages_marked_for_install: &'a IndexSet<PackageMarkedForInstall>,
+) -> Option<&'a PackageMarkedForInstall> {
+    packages_marked_for_install
+        .iter()
+        .find(|package_marked_for_install| {
+            package_name == package_marked_for_install.repository_package.name
+        })
+}
+
+fn should_visit_dependency(
+    dependency: &str,
+    system_packages: &IndexSet<SystemPackage>,
+    packages_marked_for_install: &IndexSet<PackageMarkedForInstall>,
+) -> bool {
+    // Don't bother looking at any dependencies we've already seen or that are already
+    // on the system because it'll just cause a bunch of noisy output. We only want
+    // output details about requested packages and any transitive dependencies added.
+    matches!(
+        (
+            find_system_package_by_name(dependency, system_packages),
+            find_package_marked_for_install_by_name(dependency, packages_marked_for_install)
+        ),
+        (None, None)
+    )
 }
 
 #[derive(Debug)]
@@ -253,54 +267,17 @@ impl From<DeterminePackagesToInstallError> for libcnb::Error<DebianPackagesBuild
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
-struct InstallRecord {
-    repository_package: RepositoryPackage,
-    dependency_path: Vec<String>,
-}
-
-impl Display for InstallRecord {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        if self.dependency_path.is_empty() {
-            write!(
-                f,
-                "Adding {name_with_version}",
-                name_with_version = style::value(format!(
-                    "{name}@{version}",
-                    name = self.repository_package.name,
-                    version = self.repository_package.version
-                ))
-            )
-        } else {
-            write!(
-                f,
-                "Adding {name_with_version} [from {path}]",
-                name_with_version = style::value(format!(
-                    "{name}@{version}",
-                    name = self.repository_package.name,
-                    version = self.repository_package.version
-                )),
-                path = self
-                    .dependency_path
-                    .iter()
-                    .rev()
-                    .cloned()
-                    .collect::<Vec<_>>()
-                    .join(" ← ")
-            )
-        }
-    }
-}
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-enum DependencyWarning {
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+enum PackageNotification {
+    Added {
+        repository_package: RepositoryPackage,
+        dependency_path: Vec<String>,
+    },
     AlreadyInstalledOnSystem {
-        requested_package: String,
         system_package_name: String,
         system_package_version: String,
     },
     AlreadyInstalledByOtherPackage {
-        requested_package: String,
         installed_package: RepositoryPackage,
         installed_by: String,
     },
@@ -310,26 +287,98 @@ enum DependencyWarning {
     },
 }
 
-impl Display for DependencyWarning {
+impl Display for PackageNotification {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            DependencyWarning::AlreadyInstalledOnSystem { requested_package, system_package_name, system_package_version } => write!(f,
-                "Skipping {package} because {name_with_version} is already installed on the system (consider removing {package} from your project.toml configuration for this buildpack)",
-                package = style::value(requested_package),
-                name_with_version = style::value(format!("{system_package_name}@{system_package_version}")),
-            ),
-            DependencyWarning::AlreadyInstalledByOtherPackage { requested_package, installed_package, installed_by } => write!(f,
-                "Skipping {package} because {name_with_version} was already installed as a dependency of {installed_by} (consider removing {package} from your project.toml configuration for this buildpack)",
-                package = style::value(requested_package),
-                name_with_version = style::value(format!("{name}@{version}", name = &installed_package.name, version = &installed_package.version)),
-                installed_by = style::value(installed_by),
-            ),
-            DependencyWarning::VirtualPackageHasOnlyOneImplementor { requested_package, implementor } => write!(f,
-                "Virtual package {package} is provided by {name_with_version} (consider replacing {package} with {name} in your project.toml configuration for this buildpack)",
-                package = style::value(requested_package),
-                name_with_version = style::value(format!("{name}@{version}", name = &implementor.name, version = &implementor.version)),
-                name = style::value(&implementor.name)
-            )
+            PackageNotification::Added {
+                repository_package,
+                dependency_path,
+            } => {
+                if dependency_path.is_empty() {
+                    write!(
+                        f,
+                        "Adding {name_with_version}",
+                        name_with_version = style::value(format!(
+                            "{name}@{version}",
+                            name = repository_package.name,
+                            version = repository_package.version
+                        ))
+                    )
+                } else {
+                    write!(
+                        f,
+                        "Adding {name_with_version} [from {path}]",
+                        name_with_version = style::value(format!(
+                            "{name}@{version}",
+                            name = repository_package.name,
+                            version = repository_package.version
+                        )),
+                        path = dependency_path
+                            .iter()
+                            .rev()
+                            .cloned()
+                            .collect::<Vec<_>>()
+                            .join(" ← ")
+                    )
+                }
+            }
+            PackageNotification::AlreadyInstalledOnSystem {
+                system_package_name,
+                system_package_version,
+            } => {
+                write!(f,
+                       "Skipping {package} because {name_with_version} is already installed on the system",
+                       package = style::value(system_package_name),
+                       name_with_version = style::value(format!("{system_package_name}@{system_package_version}")),
+                )
+            }
+            PackageNotification::AlreadyInstalledByOtherPackage {
+                installed_package,
+                installed_by,
+            } => {
+                write!(f,
+                       "Skipping {package} because {name_with_version} was already installed as a dependency of {installed_by}",
+                       package = style::value(&installed_package.name),
+                       name_with_version = style::value(format!("{name}@{version}", name = &installed_package.name, version = &installed_package.version)),
+                       installed_by = style::value(installed_by),
+                )
+            }
+            PackageNotification::VirtualPackageHasOnlyOneImplementor {
+                requested_package,
+                implementor,
+            } => {
+                write!(
+                    f,
+                    "Virtual package {package} is provided by {name_with_version}",
+                    package = style::value(requested_package),
+                    name_with_version = style::value(format!(
+                        "{name}@{version}",
+                        name = &implementor.name,
+                        version = &implementor.version
+                    )),
+                )
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+struct PackageMarkedForInstall {
+    repository_package: RepositoryPackage,
+    requested_by: String,
+}
+
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+struct SystemPackage {
+    package_name: String,
+    package_version: String,
+}
+
+impl From<Control> for SystemPackage {
+    fn from(value: Control) -> Self {
+        Self {
+            package_name: value.package,
+            package_version: value.version,
         }
     }
 }
@@ -338,7 +387,6 @@ impl Display for DependencyWarning {
 mod test {
     use super::*;
 
-    use std::collections::BTreeSet;
     use std::str::FromStr;
 
     use bon::builder;
@@ -349,14 +397,24 @@ mod test {
     fn install_package_already_on_the_system() {
         let package_a = create_repository_package().name("package-a").call();
 
-        let install_state = test_install_state()
+        let (new_packages_marked_for_install, package_notifications) = test_install_state()
             .with_package_index(vec![&package_a])
-            .with_system_packages(vec![&package_a])
+            .with_system_packages(IndexSet::from([create_system_package()
+                .package_name(&package_a.name)
+                .call()]))
             .install(&package_a.name)
             .call()
             .unwrap();
 
-        assert!(install_state.is_empty());
+        assert!(new_packages_marked_for_install.is_empty());
+
+        assert_eq!(
+            package_notifications,
+            IndexSet::from([PackageNotification::AlreadyInstalledOnSystem {
+                system_package_name: package_a.name.to_string(),
+                system_package_version: DEFAULT_VERSION.to_string(),
+            }])
+        );
     }
 
     #[test]
@@ -368,14 +426,30 @@ mod test {
             .depends(vec![&package_b])
             .call();
 
-        let install_state = test_install_state()
+        let (new_packages_marked_for_install, package_notifications) = test_install_state()
             .with_package_index(vec![&package_a, &package_b])
-            .with_installed(vec![&package_a, &package_b])
+            .with_installed(IndexSet::from([
+                create_package_marked_for_install()
+                    .repository_package(&package_a)
+                    .call(),
+                create_package_marked_for_install()
+                    .repository_package(&package_b)
+                    .requested_by(&package_a.name)
+                    .call(),
+            ]))
             .install(&package_b.name)
             .call()
             .unwrap();
 
-        assert!(installed_package_names(&install_state).is_empty());
+        assert!(new_packages_marked_for_install.is_empty());
+
+        assert_eq!(
+            package_notifications,
+            IndexSet::from([PackageNotification::AlreadyInstalledByOtherPackage {
+                installed_package: package_b,
+                installed_by: package_a.name,
+            }])
+        );
     }
 
     #[test]
@@ -387,15 +461,32 @@ mod test {
             .provides(vec![virtual_package])
             .call();
 
-        let install_state = test_install_state()
+        let (new_packages_marked_for_install, package_notifications) = test_install_state()
             .with_package_index(vec![&virtual_package_provider])
             .install(virtual_package)
             .call()
             .unwrap();
 
         assert_eq!(
-            installed_package_names(&install_state),
-            vec!["virtual-package-provider"]
+            new_packages_marked_for_install,
+            IndexSet::from([create_package_marked_for_install()
+                .repository_package(&virtual_package_provider)
+                .requested_by(virtual_package)
+                .call()])
+        );
+
+        assert_eq!(
+            package_notifications,
+            IndexSet::from([
+                PackageNotification::VirtualPackageHasOnlyOneImplementor {
+                    requested_package: virtual_package.to_string(),
+                    implementor: virtual_package_provider.clone()
+                },
+                PackageNotification::Added {
+                    repository_package: virtual_package_provider,
+                    dependency_path: vec![virtual_package.to_string()],
+                },
+            ])
         );
     }
 
@@ -479,24 +570,25 @@ mod test {
                 < debversion::Version::from_str(package_v1.version.as_str()).unwrap()
         );
 
-        let install_state = test_install_state()
+        let (new_packages_marked_for_install, package_notifications) = test_install_state()
             .with_package_index(vec![&package_v0, &package_v1])
             .install(package_name)
             .call()
             .unwrap();
 
         assert_eq!(
-            install_state
-                .iter()
-                .map(|(_, install_record)| {
-                    (
-                        install_record.repository_package.name.as_str(),
-                        install_record.repository_package.version.as_str(),
-                    )
-                })
-                .next()
-                .unwrap(),
-            (package_name, package_v1.version.as_str())
+            new_packages_marked_for_install,
+            IndexSet::from([create_package_marked_for_install()
+                .repository_package(&package_v1)
+                .call()])
+        );
+
+        assert_eq!(
+            package_notifications,
+            IndexSet::from([PackageNotification::Added {
+                repository_package: package_v1,
+                dependency_path: vec![],
+            }])
         );
     }
 
@@ -519,15 +611,57 @@ mod test {
             .depends(vec![&package_b])
             .call();
 
-        let install_state = test_install_state()
+        let (new_packages_marked_for_install, package_notifications) = test_install_state()
             .with_package_index(vec![&package_a, &package_b, &package_c, &package_d])
             .install(&package_a.name)
             .call()
             .unwrap();
 
         assert_eq!(
-            installed_package_names(&install_state),
-            vec!["package-a", "package-b", "package-c", "package-d"]
+            new_packages_marked_for_install,
+            IndexSet::from([
+                create_package_marked_for_install()
+                    .repository_package(&package_a)
+                    .call(),
+                create_package_marked_for_install()
+                    .repository_package(&package_b)
+                    .requested_by(&package_a.name)
+                    .call(),
+                create_package_marked_for_install()
+                    .repository_package(&package_c)
+                    .requested_by(&package_a.name)
+                    .call(),
+                create_package_marked_for_install()
+                    .repository_package(&package_d)
+                    .requested_by(&package_a.name)
+                    .call()
+            ])
+        );
+
+        assert_eq!(
+            package_notifications,
+            IndexSet::from([
+                PackageNotification::Added {
+                    repository_package: package_a.clone(),
+                    dependency_path: vec![],
+                },
+                PackageNotification::Added {
+                    repository_package: package_b.clone(),
+                    dependency_path: vec![package_a.name.to_string()],
+                },
+                PackageNotification::Added {
+                    repository_package: package_c.clone(),
+                    dependency_path: vec![package_a.name.to_string(), package_b.name.to_string()],
+                },
+                PackageNotification::Added {
+                    repository_package: package_d,
+                    dependency_path: vec![
+                        package_a.name.to_string(),
+                        package_b.name.to_string(),
+                        package_c.name.to_string()
+                    ],
+                }
+            ])
         );
     }
 
@@ -550,14 +684,27 @@ mod test {
             .depends(vec![&package_b])
             .call();
 
-        let install_state = test_install_state()
+        let (new_packages_marked_for_install, package_notifications) = test_install_state()
             .with_package_index(vec![&package_a, &package_b, &package_c, &package_d])
             .install(&package_a.name)
             .skip_dependencies(true)
             .call()
             .unwrap();
 
-        assert_eq!(installed_package_names(&install_state), vec!["package-a"]);
+        assert_eq!(
+            new_packages_marked_for_install,
+            IndexSet::from([create_package_marked_for_install()
+                .repository_package(&package_a)
+                .call(),])
+        );
+
+        assert_eq!(
+            package_notifications,
+            IndexSet::from([PackageNotification::Added {
+                repository_package: package_a,
+                dependency_path: vec![],
+            }])
+        );
     }
 
     #[test]
@@ -569,19 +716,33 @@ mod test {
             .provides(vec![package_a.name.as_str()])
             .call();
 
-        let install_state = test_install_state()
+        let (new_packages_marked_for_install, package_notifications) = test_install_state()
             .with_package_index(vec![&package_a, &package_providing_a])
             .install(&package_a.name)
             .call()
             .unwrap();
 
-        assert_eq!(installed_package_names(&install_state), vec!["package-a"]);
+        assert_eq!(
+            new_packages_marked_for_install,
+            IndexSet::from([create_package_marked_for_install()
+                .repository_package(&package_a)
+                .call()])
+        );
+
+        assert_eq!(
+            package_notifications,
+            IndexSet::from([PackageNotification::Added {
+                repository_package: package_a,
+                dependency_path: vec![]
+            }])
+        );
     }
 
     #[test]
     fn handles_circular_dependencies() {
-        let mut package_c = create_repository_package().name("package-c").call();
         let package_d = create_repository_package().name("package-d").call();
+
+        let mut package_c = create_repository_package().name("package-c").call();
 
         let package_b = create_repository_package()
             .name("package-b")
@@ -596,15 +757,129 @@ mod test {
         // because of the circular reference, we can't set it using the builder above
         package_c.depends = Some(package_a.name.clone());
 
-        let install_state = test_install_state()
+        let (new_packages_marked_for_install, package_notifications) = test_install_state()
             .with_package_index(vec![&package_a, &package_b, &package_c, &package_d])
             .install(&package_a.name)
             .call()
             .unwrap();
 
         assert_eq!(
-            installed_package_names(&install_state),
-            vec!["package-a", "package-b", "package-c", "package-d"]
+            new_packages_marked_for_install,
+            IndexSet::from([
+                create_package_marked_for_install()
+                    .repository_package(&package_a)
+                    .call(),
+                create_package_marked_for_install()
+                    .repository_package(&package_b)
+                    .requested_by(&package_a.name)
+                    .call(),
+                create_package_marked_for_install()
+                    .repository_package(&package_c)
+                    .requested_by(&package_a.name)
+                    .call(),
+                create_package_marked_for_install()
+                    .repository_package(&package_d)
+                    .requested_by(&package_a.name)
+                    .call()
+            ])
+        );
+
+        assert_eq!(
+            package_notifications,
+            IndexSet::from([
+                PackageNotification::Added {
+                    repository_package: package_a.clone(),
+                    dependency_path: vec![],
+                },
+                PackageNotification::Added {
+                    repository_package: package_b.clone(),
+                    dependency_path: vec![package_a.name.to_string()],
+                },
+                PackageNotification::Added {
+                    repository_package: package_c.clone(),
+                    dependency_path: vec![package_a.name.to_string(), package_b.name.to_string()],
+                },
+                PackageNotification::Added {
+                    repository_package: package_d,
+                    dependency_path: vec![package_a.name.to_string(), package_b.name.to_string()],
+                },
+            ])
+        );
+    }
+
+    #[test]
+    fn handle_virtual_package_with_one_implementor_that_also_exists_on_the_system() {
+        let libvips = "libvips";
+
+        let libvips42t64 = create_repository_package()
+            .name("libvips42t64")
+            .provides(vec![libvips])
+            .call();
+
+        let (new_packages_marked_for_install, package_notifications) = test_install_state()
+            .with_system_packages(IndexSet::from([create_system_package()
+                .package_name(&libvips42t64.name)
+                .call()]))
+            .with_package_index(vec![&libvips42t64])
+            .install(libvips)
+            .call()
+            .unwrap();
+
+        assert!(new_packages_marked_for_install.is_empty());
+
+        assert_eq!(
+            package_notifications,
+            IndexSet::from([
+                PackageNotification::VirtualPackageHasOnlyOneImplementor {
+                    requested_package: libvips.to_string(),
+                    implementor: libvips42t64.clone()
+                },
+                PackageNotification::AlreadyInstalledOnSystem {
+                    system_package_name: libvips42t64.name.clone(),
+                    system_package_version: libvips42t64.version.clone(),
+                }
+            ])
+        );
+    }
+
+    #[test]
+    fn handle_virtual_package_with_one_implementor_that_also_was_installed_by_a_previous_package() {
+        let libvips = "libvips";
+
+        let libvips42t64 = create_repository_package()
+            .name("libvips42t64")
+            .provides(vec![libvips])
+            .call();
+
+        let package_a = create_repository_package()
+            .name("package-a")
+            .depends(vec![&libvips42t64])
+            .call();
+
+        let (new_packages_marked_for_install, package_notifications) = test_install_state()
+            .with_package_index(vec![&package_a, &libvips42t64])
+            .with_installed(IndexSet::from([create_package_marked_for_install()
+                .repository_package(&libvips42t64)
+                .requested_by(&package_a.name)
+                .call()]))
+            .install(libvips)
+            .call()
+            .unwrap();
+
+        assert!(new_packages_marked_for_install.is_empty());
+
+        assert_eq!(
+            package_notifications,
+            IndexSet::from([
+                PackageNotification::VirtualPackageHasOnlyOneImplementor {
+                    requested_package: libvips.to_string(),
+                    implementor: libvips42t64.clone()
+                },
+                PackageNotification::AlreadyInstalledByOtherPackage {
+                    installed_package: libvips42t64,
+                    installed_by: package_a.name.to_string(),
+                }
+            ])
         );
     }
 
@@ -612,65 +887,48 @@ mod test {
     fn test_install_state(
         install: &str,
         with_package_index: Vec<&RepositoryPackage>,
-        with_installed: Option<Vec<&RepositoryPackage>>,
-        with_system_packages: Option<Vec<&RepositoryPackage>>,
+        with_installed: Option<IndexSet<PackageMarkedForInstall>>,
+        with_system_packages: Option<IndexSet<SystemPackage>>,
         skip_dependencies: Option<bool>,
-    ) -> BuildpackResult<IndexMap<String, InstallRecord>> {
+    ) -> BuildpackResult<(
+        IndexSet<PackageMarkedForInstall>,
+        IndexSet<PackageNotification>,
+    )> {
         let package_to_install = install;
+
+        let skip_dependencies = skip_dependencies.unwrap_or(false);
 
         let mut package_index = PackageIndex::default();
         for value in with_package_index {
             package_index.add_package(value.clone());
         }
 
-        let system_install_state = with_installed
-            .unwrap_or_default()
-            .into_iter()
-            .map(|repository_package| {
-                (
-                    repository_package.name.clone(),
-                    InstallRecord {
-                        repository_package: repository_package.clone(),
-                        dependency_path: vec!["dummy-package".to_string()],
-                    },
-                )
-            })
-            .collect();
+        let with_installed = with_installed.unwrap_or_default();
 
-        let mut package_install_state = IndexMap::new();
+        let mut packages_marked_for_install = with_installed.iter().cloned().collect();
 
-        let skip_dependencies = skip_dependencies.unwrap_or(false);
+        let system_packages = with_system_packages.unwrap_or_default();
+
+        let mut package_notifications = IndexSet::new();
 
         let mut visit_stack = IndexSet::new();
-
-        let mut warnings = vec![];
-
-        let system_packages = with_system_packages
-            .unwrap_or_default()
-            .into_iter()
-            .map(|repository_package| {
-                let name = repository_package.name.as_str();
-                (
-                    name.to_string(),
-                    Control::from(&format!(
-                        "Package: {name}\nVersion: 1.0.0\nArchitecture: test"
-                    ))
-                    .unwrap(),
-                )
-            })
-            .collect();
 
         visit(
             package_to_install,
             skip_dependencies,
-            &mut visit_stack,
-            &mut package_install_state,
-            &system_install_state,
-            &mut warnings,
             &system_packages,
             &package_index,
-        )
-        .map(|()| package_install_state)
+            &mut packages_marked_for_install,
+            &mut visit_stack,
+            &mut package_notifications,
+        )?;
+
+        let new_packages_marked_for_install = packages_marked_for_install
+            .difference(&with_installed)
+            .cloned()
+            .collect();
+
+        Ok((new_packages_marked_for_install, package_notifications))
     }
 
     #[builder]
@@ -689,7 +947,7 @@ mod test {
         };
         RepositoryPackage {
             name: name.to_string(),
-            version: version.unwrap_or("1.0.0").to_string(),
+            version: version.unwrap_or(DEFAULT_VERSION).to_string(),
             provides: provides.map(|vs| vs.join(",")),
             repository_uri: RepositoryUri::from(""),
             sha256sum: String::new(),
@@ -699,12 +957,24 @@ mod test {
         }
     }
 
-    fn installed_package_names(install_state: &IndexMap<String, InstallRecord>) -> Vec<String> {
-        install_state
-            .iter()
-            .map(|(k, _)| k.to_string())
-            .collect::<BTreeSet<_>>()
-            .into_iter()
-            .collect()
+    #[builder]
+    fn create_package_marked_for_install(
+        repository_package: &RepositoryPackage,
+        requested_by: Option<&str>,
+    ) -> PackageMarkedForInstall {
+        PackageMarkedForInstall {
+            repository_package: repository_package.clone(),
+            requested_by: requested_by.unwrap_or(&repository_package.name).to_string(),
+        }
     }
+
+    #[builder]
+    fn create_system_package(package_name: &str, package_version: Option<&str>) -> SystemPackage {
+        SystemPackage {
+            package_name: package_name.to_string(),
+            package_version: package_version.unwrap_or(DEFAULT_VERSION).to_string(),
+        }
+    }
+
+    const DEFAULT_VERSION: &str = "1.0.0";
 }

--- a/src/install_packages.rs
+++ b/src/install_packages.rs
@@ -2,20 +2,22 @@ use std::collections::HashMap;
 use std::env::temp_dir;
 use std::ffi::OsString;
 use std::fs::File;
-use std::io::ErrorKind;
+use std::io::{ErrorKind, Stdout, Write};
 use std::os::unix::ffi::OsStringExt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use ar::Archive as ArArchive;
 use async_compression::tokio::bufread::{GzipDecoder, XzDecoder, ZstdDecoder};
+use bullet_stream::state::Bullet;
+use bullet_stream::{style, Print};
 use futures::io::AllowStdIo;
 use futures::TryStreamExt;
 use indexmap::IndexSet;
 use libcnb::build::BuildContext;
 use libcnb::data::layer_name;
 use libcnb::layer::{
-    CachedLayerDefinition, InvalidMetadataAction, LayerState, RestoredLayerAction,
+    CachedLayerDefinition, EmptyLayerCause, InvalidMetadataAction, LayerState, RestoredLayerAction,
 };
 use libcnb::layer_env::{LayerEnv, ModificationBehavior, Scope};
 use reqwest_middleware::ClientWithMiddleware;
@@ -38,9 +40,9 @@ pub(crate) async fn install_packages(
     client: &ClientWithMiddleware,
     distro: &Distro,
     packages_to_install: Vec<RepositoryPackage>,
-) -> BuildpackResult<()> {
-    println!("## Installing packages");
-    println!();
+    mut log: Print<Bullet<Stdout>>,
+) -> BuildpackResult<Print<Bullet<Stdout>>> {
+    log = log.h2("Installing packages");
 
     let new_metadata = InstallationMetadata {
         package_checksums: packages_to_install
@@ -68,11 +70,45 @@ pub(crate) async fn install_packages(
 
     match install_layer.state {
         LayerState::Restored { .. } => {
-            for repository_package in packages_to_install {
-                println!("  Restoring {} from cache", repository_package.name);
-            }
+            log = packages_to_install
+                .iter()
+                .fold(
+                    log.bullet("Restoring packages from cache"),
+                    |log, package_to_install| {
+                        log.sub_bullet(style::value(format!(
+                            "{name}@{version}",
+                            name = package_to_install.name,
+                            version = package_to_install.version
+                        )))
+                    },
+                )
+                .done();
         }
-        LayerState::Empty { .. } => {
+        LayerState::Empty { cause } => {
+            let install_log = packages_to_install.iter().fold(
+                log.bullet(match cause {
+                    EmptyLayerCause::NewlyCreated => "Requesting packages",
+                    EmptyLayerCause::InvalidMetadataAction { .. } => {
+                        "Requesting packages (invalid metadata)"
+                    }
+                    EmptyLayerCause::RestoredLayerAction { .. } => {
+                        "Requesting packages (packages changed)"
+                    }
+                }),
+                |log, package_to_install| {
+                    log.sub_bullet(format!(
+                        "{name_with_version} from {url}",
+                        name_with_version = style::value(format!(
+                            "{name}@{version}",
+                            name = package_to_install.name,
+                            version = package_to_install.version
+                        )),
+                        url = style::url(build_download_url(package_to_install))
+                    ))
+                },
+            );
+
+            let timer = install_log.start_timer("Downloading");
             install_layer.write_metadata(new_metadata)?;
 
             let mut download_and_extract_handles = JoinSet::new();
@@ -90,6 +126,8 @@ pub(crate) async fn install_packages(
             {
                 download_and_extract_handle.map_err(InstallPackagesError::TaskFailed)??;
             }
+
+            log = timer.done().done();
         }
     }
 
@@ -102,8 +140,33 @@ pub(crate) async fn install_packages(
 
     rewrite_package_configs(&install_layer.path()).await?;
 
-    println!();
-    Ok(())
+    log = print_layer_contents(&install_layer.path(), log);
+
+    Ok(log)
+}
+
+fn print_layer_contents(install_path: &Path, log: Print<Bullet<Stdout>>) -> Print<Bullet<Stdout>> {
+    let mut directory_log = log
+        .bullet("Installation complete")
+        .start_stream("Layer file listing");
+    WalkDir::new(install_path)
+        .into_iter()
+        .flatten()
+        .filter(|entry| {
+            // filter out the env layer that's created for CNB environment files
+            if let Some(parent) = entry.path().parent() {
+                if parent == install_path.join("env") {
+                    return false;
+                }
+            }
+            entry.file_type().is_file()
+        })
+        .map(|entry| entry.path().to_path_buf())
+        .for_each(|path| {
+            let _ = writeln!(&mut directory_log, "{}", path.to_string_lossy());
+        });
+    let _ = writeln!(&mut directory_log);
+    directory_log.done().done()
 }
 
 async fn download_and_extract(
@@ -111,7 +174,6 @@ async fn download_and_extract(
     repository_package: RepositoryPackage,
     install_dir: PathBuf,
 ) -> BuildpackResult<()> {
-    println!("  Downloading and extracting {}", repository_package.name);
     let download_path = download(client, &repository_package).await?;
     extract(download_path, install_dir).await
 }
@@ -120,11 +182,7 @@ async fn download(
     client: ClientWithMiddleware,
     repository_package: &RepositoryPackage,
 ) -> BuildpackResult<PathBuf> {
-    let download_url = format!(
-        "{}/{}",
-        repository_package.repository_uri.as_str(),
-        repository_package.filename.as_str()
-    );
+    let download_url = build_download_url(repository_package);
 
     let download_file_name = PathBuf::from(repository_package.filename.as_str())
         .file_name()
@@ -404,6 +462,14 @@ async fn rewrite_package_config(package_config: &Path, install_path: &Path) -> B
     Ok(async_write(package_config, new_contents)
         .await
         .map_err(|e| InstallPackagesError::WritePackageConfig(package_config.to_path_buf(), e))?)
+}
+
+fn build_download_url(repository_package: &RepositoryPackage) -> String {
+    format!(
+        "{}/{}",
+        repository_package.repository_uri.as_str(),
+        repository_package.filename.as_str()
+    )
 }
 
 #[derive(Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use indoc::formatdoc;
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::{GenericMetadata, GenericPlatform};
-use libcnb::{buildpack_main, Buildpack};
+use libcnb::{buildpack_main, Buildpack, Env};
 use reqwest::Client;
 use reqwest_middleware::ClientBuilder;
 use reqwest_retry::policies::ExponentialBackoff;
@@ -156,4 +156,10 @@ impl From<DebianPackagesBuildpackError> for libcnb::Error<DebianPackagesBuildpac
     fn from(value: DebianPackagesBuildpackError) -> Self {
         Self::BuildpackError(value)
     }
+}
+
+pub(crate) fn is_buildpack_debug_logging_enabled() -> bool {
+    Env::from_current()
+        .get("BP_LOG_LEVEL")
+        .is_some_and(|value| value.to_ascii_lowercase() == "debug")
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,8 @@ use std::io::stdout;
 use std::sync::Arc;
 use std::time::Duration;
 
+use bullet_stream::Print;
+use indoc::formatdoc;
 use libcnb::build::{BuildContext, BuildResult, BuildResultBuilder};
 use libcnb::detect::{DetectContext, DetectResult, DetectResultBuilder};
 use libcnb::generic::{GenericMetadata, GenericPlatform};
@@ -48,14 +50,17 @@ impl Buildpack for DebianPackagesBuildpack {
         if BuildpackConfig::exists(context.app_dir.join("project.toml"))? {
             DetectResultBuilder::pass().build()
         } else {
-            println!("No project.toml file found.");
+            Print::new(stdout())
+                .without_header()
+                .important("No project.toml file found.")
+                .done();
             DetectResultBuilder::fail().build()
         }
     }
 
     fn build(&self, context: BuildContext<Self>) -> libcnb::Result<BuildResult, Self::Error> {
-        println!(
-            "# {buildpack_name} (v{buildpack_version})",
+        let mut log = Print::new(stdout()).h1(format!(
+            "{buildpack_name} (v{buildpack_version})",
             buildpack_name = context
                 .buildpack_descriptor
                 .buildpack
@@ -63,26 +68,24 @@ impl Buildpack for DebianPackagesBuildpack {
                 .as_ref()
                 .expect("buildpack name should be set"),
             buildpack_version = context.buildpack_descriptor.buildpack.version
-        );
-        println!();
+        ));
 
         let config = BuildpackConfig::try_from(context.app_dir.join("project.toml"))?;
 
         if config.install.is_empty() {
-            println!(
-                "{message}",
-                message = "
-No configured packages to install found in project.toml file. You may need to \
-add a list of packages to install in your project.toml like this:
+            log.important(
+                formatdoc! {"
+                    No configured packages to install found in project.toml file. You may need to \
+                add a list of packages to install in your project.toml like this:
 
-[com.heroku.buildpacks.deb-packages]
-install = [
-  \"package-name\",
-]
-            "
-                .trim()
-            );
-            println!();
+                [com.heroku.buildpacks.deb-packages]
+                install = [
+                    \"package-name\",
+                ]
+            " }
+                .trim(),
+            )
+            .done();
             return BuildResultBuilder::new().build();
         }
 
@@ -108,25 +111,29 @@ install = [
             .build()
             .expect("Should be able to construct the Async Runtime");
 
-        println!("## Distribution Info");
-        println!();
-        println!("- Name: {}", &distro.name);
-        println!("- Version: {}", &distro.version);
-        println!("- Codename: {}", &distro.codename);
-        println!("- Architecture: {}", &distro.architecture);
-        println!();
+        log = log
+            .bullet("Distribution Info")
+            .sub_bullet(format!("Name: {}", &distro.name))
+            .sub_bullet(format!("Version: {}", &distro.version))
+            .sub_bullet(format!("Codename: {}", &distro.codename))
+            .sub_bullet(format!("Architecture: {}", &distro.architecture))
+            .done();
 
-        let package_index =
-            runtime.block_on(create_package_index(&shared_context, &client, &distro))?;
+        let (package_index, log) =
+            runtime.block_on(create_package_index(&shared_context, &client, &distro, log))?;
 
-        let packages_to_install = determine_packages_to_install(&package_index, config.install)?;
+        let (packages_to_install, log) =
+            determine_packages_to_install(&package_index, config.install, log)?;
 
-        runtime.block_on(install_packages(
+        let log = runtime.block_on(install_packages(
             &shared_context,
             &client,
             &distro,
             packages_to_install,
+            log,
         ))?;
+
+        log.done();
 
         BuildResultBuilder::new().build()
     }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -62,104 +62,142 @@ fn test_general_usage_output() {
 
         match (get_integration_test_builder().as_str(), get_integration_test_arch().as_str()) {
             ("heroku/builder:22", "amd64") => {
-                assert_contains!(ctx.pack_stdout, "## Distribution Info");
-
-                assert_contains!(ctx.pack_stdout, "- Name: ubuntu");
-                assert_contains!(ctx.pack_stdout, "- Version: 22.04");
-                assert_contains!(ctx.pack_stdout, "- Codename: jammy");
-                assert_contains!(ctx.pack_stdout, "- Architecture: amd64");
+                assert_contains!(ctx.pack_stdout, "Distribution Info");
+                assert_contains!(ctx.pack_stdout, "Name: ubuntu");
+                assert_contains!(ctx.pack_stdout, "Version: 22.04");
+                assert_contains!(ctx.pack_stdout, "Codename: jammy");
+                assert_contains!(ctx.pack_stdout, "Architecture: amd64");
 
                 assert_contains!(ctx.pack_stdout, "## Creating package index");
-
-                assert_contains_match!(ctx.pack_stdout, r"\[GET\] http://archive.ubuntu.com/ubuntu/dists/jammy/InRelease");
-                assert_contains_match!(ctx.pack_stdout, r"\[GET\] http://archive.ubuntu.com/ubuntu/dists/jammy/main/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
-                assert_contains_match!(ctx.pack_stdout, r"\[GET\] http://archive.ubuntu.com/ubuntu/dists/jammy/universe/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
-                assert_contains_match!(ctx.pack_stdout, r"\[GET\] http://archive.ubuntu.com/ubuntu/dists/jammy-security/InRelease");
-                assert_contains_match!(ctx.pack_stdout, r"\[GET\] http://archive.ubuntu.com/ubuntu/dists/jammy-security/main/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
-                assert_contains_match!(ctx.pack_stdout, r"\[GET\] http://archive.ubuntu.com/ubuntu/dists/jammy-security/universe/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
-                assert_contains_match!(ctx.pack_stdout, r"\[GET\] http://archive.ubuntu.com/ubuntu/dists/jammy-updates/InRelease");
-                assert_contains_match!(ctx.pack_stdout, r"\[GET\] http://archive.ubuntu.com/ubuntu/dists/jammy-updates/main/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
-                assert_contains_match!(ctx.pack_stdout, r"\[GET\] http://archive.ubuntu.com/ubuntu/dists/jammy-updates/universe/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
-
-                assert_contains!(ctx.pack_stdout, "Processing package files...");
-                assert_contains_match!(ctx.pack_stdout, r"Indexed \d+ packages \(\d+ms\)");
+                assert_contains!(ctx.pack_stdout, "Package sources");
+                assert_contains!(ctx.pack_stdout, "http://archive.ubuntu.com/ubuntu jammy [main, universe]");
+                assert_contains!(ctx.pack_stdout, "http://archive.ubuntu.com/ubuntu jammy-security [main, universe]");
+                assert_contains!(ctx.pack_stdout, "http://archive.ubuntu.com/ubuntu jammy-updates [main, universe]");
+                assert_contains!(ctx.pack_stdout, "Updating");
+                assert_contains_match!(ctx.pack_stdout, r"Downloaded release file http://archive.ubuntu.com/ubuntu/dists/jammy/InRelease");
+                assert_contains_match!(ctx.pack_stdout, r"Downloaded package index http://archive.ubuntu.com/ubuntu/dists/jammy/main/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
+                assert_contains_match!(ctx.pack_stdout, r"Downloaded package index http://archive.ubuntu.com/ubuntu/dists/jammy/universe/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
+                assert_contains_match!(ctx.pack_stdout, r"Downloaded release file http://archive.ubuntu.com/ubuntu/dists/jammy-security/InRelease");
+                assert_contains_match!(ctx.pack_stdout, r"Downloaded package index http://archive.ubuntu.com/ubuntu/dists/jammy-security/main/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
+                assert_contains_match!(ctx.pack_stdout, r"Downloaded package index http://archive.ubuntu.com/ubuntu/dists/jammy-security/universe/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
+                assert_contains_match!(ctx.pack_stdout, r"Downloaded release file http://archive.ubuntu.com/ubuntu/dists/jammy-updates/InRelease");
+                assert_contains_match!(ctx.pack_stdout, r"Downloaded package index http://archive.ubuntu.com/ubuntu/dists/jammy-updates/main/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
+                assert_contains_match!(ctx.pack_stdout, r"Downloaded package index http://archive.ubuntu.com/ubuntu/dists/jammy-updates/universe/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
+                assert_contains!(ctx.pack_stdout, "Building package index");
+                assert_contains!(ctx.pack_stdout, "Processing package files");
+                assert_contains_match!(ctx.pack_stdout, r"Indexed \d+ packages");
 
                 assert_contains!(ctx.pack_stdout, "## Determining packages to install");
-
-                assert_contains!(ctx.pack_stdout, "Adding libgwenhywfar79@5.9.0-1");
-                assert_contains!(ctx.pack_stdout, "Adding libgwenhywfar-data@5.9.0-1 [from libgwenhywfar79]");
+                assert_contains!(ctx.pack_stdout, "Collecting system install information");
+                assert_contains!(ctx.pack_stdout, "Determining install requirements for requested package `libgwenhywfar79`");
+                assert_contains!(ctx.pack_stdout, "Adding `libgwenhywfar79@5.9.0-1`");
+                assert_contains!(ctx.pack_stdout, "Adding `libgwenhywfar-data@5.9.0-1` [from libgwenhywfar79]");
+                assert_contains!(ctx.pack_stdout, "Determining install requirements for requested package `libgwenhywfar-data`");
+                assert_contains!(ctx.pack_stdout, "Nothing to add");
+                assert_contains!(ctx.pack_stdout, "Determining install requirements for requested package `xmlsec1`");
+                assert_contains!(ctx.pack_stdout, "Adding `xmlsec1@1.2.33-1build2`");
+                assert_contains!(ctx.pack_stdout, "Determining install requirements for requested package `wget`");
+                assert_contains!(ctx.pack_stdout, "Nothing to add");
+                assert_contains!(ctx.pack_stdout, "Determining install requirements for requested package `libvips`");
+                assert_contains!(ctx.pack_stdout, "Nothing to add");
                 assert_contains!(
                     ctx.pack_stdout,
-                    "! Skipping libgwenhywfar-data because libgwenhywfar-data@5.9.0-1 was already installed as a dependency of libgwenhywfar79 (consider removing libgwenhywfar-data from your project.toml configuration for this buildpack)"
+                    "! Skipping `libgwenhywfar-data` because `libgwenhywfar-data@5.9.0-1` was already installed as a dependency of `libgwenhywfar79` (consider removing `libgwenhywfar-data` from your project.toml configuration for this buildpack)"
                 );
-                assert_contains!(ctx.pack_stdout, "Adding xmlsec1@1.2.33-1build2");
-                assert_contains_match!(ctx.pack_stdout, "! Skipping wget because wget@1.21.2-.* is already installed on the system \\(consider removing wget from your project.toml configuration for this buildpack\\)");
-                assert_contains!(
+                assert_contains_match!(
                     ctx.pack_stdout,
-                    "! Virtual package libvips is provided by libvips42@8.12.1-1build1 (consider replacing libvips for libvips42 in your project.toml configuration for this buildpack)"
+                    "! Skipping `wget` because `wget@1.21.2-.*` is already installed on the system \\(consider removing `wget` from your project.toml configuration for this buildpack\\)"
                 );
                 assert_contains!(
                     ctx.pack_stdout,
-                    "! Skipping libvips42 because libvips42@8.12.1-1build1 is already installed on the system (consider removing libvips42 from your project.toml configuration for this buildpack)"
+                    "! Virtual package `libvips` is provided by `libvips42@8.12.1-1build1` (consider replacing `libvips` with `libvips42` in your project.toml configuration for this buildpack)"
+                );
+                assert_contains!(
+                    ctx.pack_stdout,
+                    "! Skipping `libvips42` because `libvips42@8.12.1-1build1` is already installed on the system (consider removing `libvips42` from your project.toml configuration for this buildpack)"
                 );
 
                 assert_contains!(ctx.pack_stdout, "## Installing packages");
-
-                assert_contains!(ctx.pack_stdout, "Downloading and extracting libgwenhywfar79");
-                assert_contains!(ctx.pack_stdout, "Downloading and extracting xmlsec1");
-                assert_contains!(ctx.pack_stdout, "Downloading and extracting libgwenhywfar-data");
+                assert_contains!(ctx.pack_stdout, "Requesting packages");
+                assert_contains!(ctx.pack_stdout, "`libgwenhywfar79@5.9.0-1` from http://archive.ubuntu.com/ubuntu/pool/universe/libg/libgwenhywfar/libgwenhywfar79_5.9.0-1_amd64.deb");
+                assert_contains!(ctx.pack_stdout, "`libgwenhywfar-data@5.9.0-1` from http://archive.ubuntu.com/ubuntu/pool/universe/libg/libgwenhywfar/libgwenhywfar-data_5.9.0-1_all.deb");
+                assert_contains!(ctx.pack_stdout, "`xmlsec1@1.2.33-1build2` from http://archive.ubuntu.com/ubuntu/pool/main/x/xmlsec1/xmlsec1_1.2.33-1build2_amd64.deb");
+                assert_contains!(ctx.pack_stdout, "Downloading");
+                assert_contains!(ctx.pack_stdout, "Installation complete");
+                assert_contains!(ctx.pack_stdout, "Layer file listing");
+                assert_contains!(ctx.pack_stdout, "/layers/heroku_deb-packages/packages/usr/bin/xmlsec1");
+                assert_contains!(ctx.pack_stdout, "/layers/heroku_deb-packages/packages/usr/lib/x86_64-linux-gnu/libgwenhywfar.so");
             }
             ("heroku/builder:24", "amd64") => {
-                assert_contains!(ctx.pack_stdout, "## Distribution Info");
-
-                assert_contains!(ctx.pack_stdout, "- Name: ubuntu");
-                assert_contains!(ctx.pack_stdout, "- Version: 24.04");
-                assert_contains!(ctx.pack_stdout, "- Codename: noble");
-                assert_contains!(ctx.pack_stdout, "- Architecture: amd64");
+                assert_contains!(ctx.pack_stdout, "Distribution Info");
+                assert_contains!(ctx.pack_stdout, "Name: ubuntu");
+                assert_contains!(ctx.pack_stdout, "Version: 24.04");
+                assert_contains!(ctx.pack_stdout, "Codename: noble");
+                assert_contains!(ctx.pack_stdout, "Architecture: amd64");
 
                 assert_contains!(ctx.pack_stdout, "## Creating package index");
-
-                assert_contains_match!(ctx.pack_stdout, r"\[GET\] http://archive.ubuntu.com/ubuntu/dists/noble/InRelease");
-                assert_contains_match!(ctx.pack_stdout, r"\[GET\] http://archive.ubuntu.com/ubuntu/dists/noble/main/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
-                assert_contains_match!(ctx.pack_stdout, r"\[GET\] http://archive.ubuntu.com/ubuntu/dists/noble/universe/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
-                assert_contains_match!(ctx.pack_stdout, r"\[GET\] http://security.ubuntu.com/ubuntu/dists/noble-security/InRelease");
-                assert_contains_match!(ctx.pack_stdout, r"\[GET\] http://security.ubuntu.com/ubuntu/dists/noble-security/main/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
-                assert_contains_match!(ctx.pack_stdout, r"\[GET\] http://security.ubuntu.com/ubuntu/dists/noble-security/universe/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
-                assert_contains_match!(ctx.pack_stdout, r"\[GET\] http://archive.ubuntu.com/ubuntu/dists/noble-updates/InRelease");
-                assert_contains_match!(ctx.pack_stdout, r"\[GET\] http://archive.ubuntu.com/ubuntu/dists/noble-updates/main/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
-                assert_contains_match!(ctx.pack_stdout, r"\[GET\] http://archive.ubuntu.com/ubuntu/dists/noble-updates/universe/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
-
-                assert_contains!(ctx.pack_stdout, "Processing package files...");
-                assert_contains_match!(ctx.pack_stdout, r"Indexed \d+ packages \(\d+ms\)");
+                assert_contains!(ctx.pack_stdout, "Package sources");
+                assert_contains!(ctx.pack_stdout, "http://archive.ubuntu.com/ubuntu noble [main, universe]");
+                assert_contains!(ctx.pack_stdout, "http://security.ubuntu.com/ubuntu noble-security [main, universe]");
+                assert_contains!(ctx.pack_stdout, "http://archive.ubuntu.com/ubuntu noble-updates [main, universe]");
+                assert_contains!(ctx.pack_stdout, "Updating");
+                assert_contains_match!(ctx.pack_stdout, r"Downloaded release file http://archive.ubuntu.com/ubuntu/dists/noble/InRelease");
+                assert_contains_match!(ctx.pack_stdout, r"Downloaded package index http://archive.ubuntu.com/ubuntu/dists/noble/main/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
+                assert_contains_match!(ctx.pack_stdout, r"Downloaded package index http://archive.ubuntu.com/ubuntu/dists/noble/universe/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
+                assert_contains_match!(ctx.pack_stdout, r"Downloaded release file http://security.ubuntu.com/ubuntu/dists/noble-security/InRelease");
+                assert_contains_match!(ctx.pack_stdout, r"Downloaded package index http://security.ubuntu.com/ubuntu/dists/noble-security/main/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
+                assert_contains_match!(ctx.pack_stdout, r"Downloaded package index http://security.ubuntu.com/ubuntu/dists/noble-security/universe/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
+                assert_contains_match!(ctx.pack_stdout, r"Downloaded release file http://archive.ubuntu.com/ubuntu/dists/noble-updates/InRelease");
+                assert_contains_match!(ctx.pack_stdout, r"Downloaded package index http://archive.ubuntu.com/ubuntu/dists/noble-updates/main/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
+                assert_contains_match!(ctx.pack_stdout, r"Downloaded package index http://archive.ubuntu.com/ubuntu/dists/noble-updates/universe/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
+                assert_contains!(ctx.pack_stdout, "Building package index");
+                assert_contains!(ctx.pack_stdout, "Processing package files");
+                assert_contains_match!(ctx.pack_stdout, r"Indexed \d+ packages");
 
                 assert_contains!(ctx.pack_stdout, "## Determining packages to install");
-
+                assert_contains!(ctx.pack_stdout, "Collecting system install information");
+                assert_contains!(ctx.pack_stdout, "Determining install requirements for requested package `libgwenhywfar79`");
+                assert_contains!(ctx.pack_stdout, "Adding `libgwenhywfar79t64@5.10.2-2.1build4`");
+                assert_contains!(ctx.pack_stdout, "Adding `libgwenhywfar-data@5.10.2-2.1build4` [from libgwenhywfar79t64]");
+                assert_contains!(ctx.pack_stdout, "Determining install requirements for requested package `libgwenhywfar-data`");
+                assert_contains!(ctx.pack_stdout, "Nothing to add");
+                assert_contains!(ctx.pack_stdout, "Determining install requirements for requested package `xmlsec1`");
+                assert_contains!(ctx.pack_stdout, "Adding `xmlsec1@1.2.39-5build2`");
+                assert_contains!(ctx.pack_stdout, "Determining install requirements for requested package `wget`");
+                assert_contains!(ctx.pack_stdout, "Nothing to add");
+                assert_contains!(ctx.pack_stdout, "Determining install requirements for requested package `libvips`");
+                assert_contains!(ctx.pack_stdout, "Nothing to add");
                 assert_contains!(
                     ctx.pack_stdout,
-                    "! Virtual package libgwenhywfar79 is provided by libgwenhywfar79t64@5.10.2-2.1build4 (consider replacing libgwenhywfar79 for libgwenhywfar79t64 in your project.toml configuration for this buildpack)"
+                    "! Virtual package `libgwenhywfar79` is provided by `libgwenhywfar79t64@5.10.2-2.1build4` (consider replacing `libgwenhywfar79` with `libgwenhywfar79t64` in your project.toml configuration for this buildpack)"
                 );
-                assert_contains!(ctx.pack_stdout, "Adding libgwenhywfar79t64@5.10.2-2.1build4");
-                assert_contains!(ctx.pack_stdout, "Adding libgwenhywfar-data@5.10.2-2.1build4 [from libgwenhywfar79t64]");
                 assert_contains!(
                     ctx.pack_stdout,
-                    "! Skipping libgwenhywfar-data because libgwenhywfar-data@5.10.2-2.1build4 was already installed as a dependency of libgwenhywfar79t64 (consider removing libgwenhywfar-data from your project.toml configuration for this buildpack)"
+                    "! Skipping `libgwenhywfar-data` because `libgwenhywfar-data@5.10.2-2.1build4` was already installed as a dependency of `libgwenhywfar79t64` (consider removing `libgwenhywfar-data` from your project.toml configuration for this buildpack)"
                 );
-                assert_contains!(ctx.pack_stdout, "Adding xmlsec1@1.2.39-5build2");
-                assert_contains_match!(ctx.pack_stdout, "! Skipping wget because wget@1.21.4-.* is already installed on the system \\(consider removing wget from your project.toml configuration for this buildpack\\)");
-                assert_contains!(
+                assert_contains_match!(
                     ctx.pack_stdout,
-                    "! Virtual package libvips is provided by libvips42t64@8.15.1-1.1build4 (consider replacing libvips for libvips42t64 in your project.toml configuration for this buildpack)"
+                    "! Skipping `wget` because `wget@1.21.4-.*` is already installed on the system \\(consider removing `wget` from your project.toml configuration for this buildpack\\)"
                 );
                 assert_contains!(
                     ctx.pack_stdout,
-                    "! Skipping libvips42t64 because libvips42t64@8.15.1-1.1build4 is already installed on the system (consider removing libvips42t64 from your project.toml configuration for this buildpack)"
+                    "! Virtual package `libvips` is provided by `libvips42t64@8.15.1-1.1build4` (consider replacing `libvips` with `libvips42t64` in your project.toml configuration for this buildpack)"
+                );
+                assert_contains!(
+                    ctx.pack_stdout,
+                    "! Skipping `libvips42t64` because `libvips42t64@8.15.1-1.1build4` is already installed on the system (consider removing `libvips42t64` from your project.toml configuration for this buildpack)"
                 );
 
                 assert_contains!(ctx.pack_stdout, "## Installing packages");
-
-                assert_contains!(ctx.pack_stdout, "Downloading and extracting libgwenhywfar79t64");
-                assert_contains!(ctx.pack_stdout, "Downloading and extracting xmlsec1");
-                assert_contains!(ctx.pack_stdout, "Downloading and extracting libgwenhywfar-data");
+                assert_contains!(ctx.pack_stdout, "Requesting packages");
+                assert_contains!(ctx.pack_stdout, "`libgwenhywfar79t64@5.10.2-2.1build4` from http://archive.ubuntu.com/ubuntu/pool/universe/libg/libgwenhywfar/libgwenhywfar79t64_5.10.2-2.1build4_amd64.deb");
+                assert_contains!(ctx.pack_stdout, "`libgwenhywfar-data@5.10.2-2.1build4` from http://archive.ubuntu.com/ubuntu/pool/universe/libg/libgwenhywfar/libgwenhywfar-data_5.10.2-2.1build4_all.deb");
+                assert_contains!(ctx.pack_stdout, "`xmlsec1@1.2.39-5build2` from http://archive.ubuntu.com/ubuntu/pool/main/x/xmlsec1/xmlsec1_1.2.39-5build2_amd64.deb");
+                assert_contains!(ctx.pack_stdout, "Downloading");
+                assert_contains!(ctx.pack_stdout, "Installation complete");
+                assert_contains!(ctx.pack_stdout, "Layer file listing");
+                assert_contains!(ctx.pack_stdout, "/layers/heroku_deb-packages/packages/usr/bin/xmlsec1");
+                assert_contains!(ctx.pack_stdout, "/layers/heroku_deb-packages/packages/usr/lib/x86_64-linux-gnu/libgwenhywfar.so");
             }
             ("heroku/builder:24", "arm64") => {
                 assert_contains!(ctx.pack_stdout, "## Distribution Info");
@@ -228,34 +266,36 @@ fn test_general_usage_output_on_rebuild() {
 
             match (get_integration_test_builder().as_str(), get_integration_test_arch().as_str()) {
                 ("heroku/builder:22", "amd64") => {
-                    assert_contains_match!(ctx.pack_stdout, r"\[CACHED\] http://archive.ubuntu.com/ubuntu/dists/jammy/InRelease");
-                    assert_contains_match!(ctx.pack_stdout, r"\[CACHED\] http://archive.ubuntu.com/ubuntu/dists/jammy/main/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
-                    assert_contains_match!(ctx.pack_stdout, r"\[CACHED\] http://archive.ubuntu.com/ubuntu/dists/jammy/universe/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
-                    assert_contains_match!(ctx.pack_stdout, r"\[CACHED\] http://archive.ubuntu.com/ubuntu/dists/jammy-security/InRelease");
-                    assert_contains_match!(ctx.pack_stdout, r"\[CACHED\] http://archive.ubuntu.com/ubuntu/dists/jammy-security/main/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
-                    assert_contains_match!(ctx.pack_stdout, r"\[CACHED\] http://archive.ubuntu.com/ubuntu/dists/jammy-security/universe/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
-                    assert_contains_match!(ctx.pack_stdout, r"\[CACHED\] http://archive.ubuntu.com/ubuntu/dists/jammy-updates/InRelease");
-                    assert_contains_match!(ctx.pack_stdout, r"\[CACHED\] http://archive.ubuntu.com/ubuntu/dists/jammy-updates/main/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
-                    assert_contains_match!(ctx.pack_stdout, r"\[CACHED\] http://archive.ubuntu.com/ubuntu/dists/jammy-updates/universe/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
+                    assert_contains_match!(ctx.pack_stdout, r"Restored release file from cache \(http://archive.ubuntu.com/ubuntu/dists/jammy/InRelease\)");
+                    assert_contains_match!(ctx.pack_stdout, r"Restored package index from cache \(http://archive.ubuntu.com/ubuntu/dists/jammy/main/binary-amd64/by-hash/SHA256/[0-9a-f]+\)");
+                    assert_contains_match!(ctx.pack_stdout, r"Restored package index from cache \(http://archive.ubuntu.com/ubuntu/dists/jammy/universe/binary-amd64/by-hash/SHA256/[0-9a-f]+\)");
+                    assert_contains_match!(ctx.pack_stdout, r"Restored release file from cache \(http://archive.ubuntu.com/ubuntu/dists/jammy-security/InRelease\)");
+                    assert_contains_match!(ctx.pack_stdout, r"Restored package index from cache \(http://archive.ubuntu.com/ubuntu/dists/jammy-security/main/binary-amd64/by-hash/SHA256/[0-9a-f]+\)");
+                    assert_contains_match!(ctx.pack_stdout, r"Restored package index from cache \(http://archive.ubuntu.com/ubuntu/dists/jammy-security/universe/binary-amd64/by-hash/SHA256/[0-9a-f]+\)");
+                    assert_contains_match!(ctx.pack_stdout, r"Restored release file from cache \(http://archive.ubuntu.com/ubuntu/dists/jammy-updates/InRelease\)");
+                    assert_contains_match!(ctx.pack_stdout, r"Restored package index from cache \(http://archive.ubuntu.com/ubuntu/dists/jammy-updates/main/binary-amd64/by-hash/SHA256/[0-9a-f]+\)");
+                    assert_contains_match!(ctx.pack_stdout, r"Restored package index from cache \(http://archive.ubuntu.com/ubuntu/dists/jammy-updates/universe/binary-amd64/by-hash/SHA256/[0-9a-f]+\)");
 
-                    assert_contains!(ctx.pack_stdout, "Restoring xmlsec1 from cache");
-                    assert_contains!(ctx.pack_stdout, "Restoring libgwenhywfar-data from cache");
-                    assert_contains!(ctx.pack_stdout, "Restoring libgwenhywfar79 from cache");
+                    assert_contains!(ctx.pack_stdout, "Restoring packages from cache");
+                    assert_contains!(ctx.pack_stdout, "`libgwenhywfar79@5.9.0-1`");
+                    assert_contains!(ctx.pack_stdout, "`libgwenhywfar-data@5.9.0-1`");
+                    assert_contains!(ctx.pack_stdout, "`xmlsec1@1.2.33-1build2`");
                 }
                 ("heroku/builder:24", "amd64") => {
-                    assert_contains_match!(ctx.pack_stdout, r"\[CACHED\] http://archive.ubuntu.com/ubuntu/dists/noble/InRelease");
-                    assert_contains_match!(ctx.pack_stdout, r"\[CACHED\] http://archive.ubuntu.com/ubuntu/dists/noble/main/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
-                    assert_contains_match!(ctx.pack_stdout, r"\[CACHED\] http://archive.ubuntu.com/ubuntu/dists/noble/universe/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
-                    assert_contains_match!(ctx.pack_stdout, r"\[CACHED\] http://security.ubuntu.com/ubuntu/dists/noble-security/InRelease");
-                    assert_contains_match!(ctx.pack_stdout, r"\[CACHED\] http://security.ubuntu.com/ubuntu/dists/noble-security/main/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
-                    assert_contains_match!(ctx.pack_stdout, r"\[CACHED\] http://security.ubuntu.com/ubuntu/dists/noble-security/universe/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
-                    assert_contains_match!(ctx.pack_stdout, r"\[CACHED\] http://archive.ubuntu.com/ubuntu/dists/noble-updates/InRelease");
-                    assert_contains_match!(ctx.pack_stdout, r"\[CACHED\] http://archive.ubuntu.com/ubuntu/dists/noble-updates/main/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
-                    assert_contains_match!(ctx.pack_stdout, r"\[CACHED\] http://archive.ubuntu.com/ubuntu/dists/noble-updates/universe/binary-amd64/by-hash/SHA256/[0-9a-f]+$");
+                    assert_contains_match!(ctx.pack_stdout, r"Restored release file from cache \(http://archive.ubuntu.com/ubuntu/dists/noble/InRelease\)");
+                    assert_contains_match!(ctx.pack_stdout, r"Restored package index from cache \(http://archive.ubuntu.com/ubuntu/dists/noble/main/binary-amd64/by-hash/SHA256/[0-9a-f]+\)");
+                    assert_contains_match!(ctx.pack_stdout, r"Restored package index from cache \(http://archive.ubuntu.com/ubuntu/dists/noble/universe/binary-amd64/by-hash/SHA256/[0-9a-f]+\)");
+                    assert_contains_match!(ctx.pack_stdout, r"Restored release file from cache \(http://security.ubuntu.com/ubuntu/dists/noble-security/InRelease\)");
+                    assert_contains_match!(ctx.pack_stdout, r"Restored package index from cache \(http://security.ubuntu.com/ubuntu/dists/noble-security/main/binary-amd64/by-hash/SHA256/[0-9a-f]+\)");
+                    assert_contains_match!(ctx.pack_stdout, r"Restored package index from cache \(http://security.ubuntu.com/ubuntu/dists/noble-security/universe/binary-amd64/by-hash/SHA256/[0-9a-f]+\)");
+                    assert_contains_match!(ctx.pack_stdout, r"Restored release file from cache \(http://archive.ubuntu.com/ubuntu/dists/noble-updates/InRelease\)");
+                    assert_contains_match!(ctx.pack_stdout, r"Restored package index from cache \(http://archive.ubuntu.com/ubuntu/dists/noble-updates/main/binary-amd64/by-hash/SHA256/[0-9a-f]+\)");
+                    assert_contains_match!(ctx.pack_stdout, r"Restored package index from cache \(http://archive.ubuntu.com/ubuntu/dists/noble-updates/universe/binary-amd64/by-hash/SHA256/[0-9a-f]+\)");
 
-                    assert_contains!(ctx.pack_stdout, "Restoring xmlsec1 from cache");
-                    assert_contains!(ctx.pack_stdout, "Restoring libgwenhywfar-data from cache");
-                    assert_contains!(ctx.pack_stdout, "Restoring libgwenhywfar79t64 from cache");
+                    assert_contains!(ctx.pack_stdout, "Restoring packages from cache");
+                    assert_contains!(ctx.pack_stdout, "`libgwenhywfar79t64@5.10.2-2.1build4`");
+                    assert_contains!(ctx.pack_stdout, "`libgwenhywfar-data@5.10.2-2.1build4`");
+                    assert_contains!(ctx.pack_stdout, "`xmlsec1@1.2.39-5build2`");
                 }
                 ("heroku/builder:24", "arm64") => {
                     assert_contains_match!(ctx.pack_stdout, r"\[CACHED\] http://ports.ubuntu.com/ubuntu-ports/dists/noble/InRelease");
@@ -373,14 +413,23 @@ fn test_cache_invalidated_when_configuration_changes() {
         |ctx| {
             match (get_integration_test_builder().as_str(), get_integration_test_arch().as_str()) {
                 ("heroku/builder:22", "amd64") => {
-                    assert_contains!(ctx.pack_stdout, "Adding libxmlsec1@1.2.33-1build2");
-                    assert_contains!(ctx.pack_stdout, "Downloading and extracting libxmlsec1");
+                    assert_contains!(ctx.pack_stdout, "Requesting packages");
+                    assert_contains!(ctx.pack_stdout, "Adding `libxmlsec1@1.2.33-1build2`");
+                    assert_contains!(ctx.pack_stdout, "`libxmlsec1@1.2.33-1build2` from http://archive.ubuntu.com/ubuntu/pool/main/x/xmlsec1/libxmlsec1_1.2.33-1build2_amd64.deb");
+
+                    assert_not_contains!(ctx.pack_stdout, "Adding `libgwenhywfar-data@5.9.0-1`");
+                    assert_not_contains!(ctx.pack_stdout, "`libgwenhywfar-data@5.9.0-1` from http://archive.ubuntu.com/ubuntu/pool/universe/libg/libgwenhywfar/libgwenhywfar-data_5.9.0-1_all.deb");
                 }
                 ("heroku/builder:24", "amd64") => {
-                    assert_contains!(ctx.pack_stdout, "Adding libxmlsec1t64@1.2.39-5build2");
-                    assert_contains!(ctx.pack_stdout, "Downloading and extracting libxmlsec1t64");
+                    assert_contains!(ctx.pack_stdout, "Requesting packages");
+                    assert_contains!(ctx.pack_stdout, "Adding `libxmlsec1t64@1.2.39-5build2`");
+                    assert_contains!(ctx.pack_stdout, "`libxmlsec1t64@1.2.39-5build2` from http://archive.ubuntu.com/ubuntu/pool/main/x/xmlsec1/libxmlsec1t64_1.2.39-5build2_amd64.deb");
+
+                    assert_not_contains!(ctx.pack_stdout, "Adding `libgwenhywfar-data@5.10.2-2.1build4`");
+                    assert_not_contains!(ctx.pack_stdout, "`libgwenhywfar-data@5.10.2-2.1build4` from http://archive.ubuntu.com/ubuntu/pool/universe/libg/libgwenhywfar/libgwenhywfar-data@5.10.2-2.1build4_all.deb");
                 }
                 ("heroku/builder:24", "arm64") => {
+                    assert_contains!(ctx.pack_stdout, "Requesting packages");
                     assert_contains!(ctx.pack_stdout, "Adding libxmlsec1t64@1.2.39-5build2");
                     assert_contains!(ctx.pack_stdout, "Downloading and extracting libxmlsec1t64");
                 }
@@ -394,20 +443,23 @@ fn test_cache_invalidated_when_configuration_changes() {
                 }),
                 |ctx| match (get_integration_test_builder().as_str(), get_integration_test_arch().as_str()) {
                     ("heroku/builder:22", "amd64") => {
-                        assert_contains!(ctx.pack_stdout, "Adding libgwenhywfar-data@5.9.0-1");
-                        assert_contains!(ctx.pack_stdout, "Downloading and extracting libgwenhywfar-data");
+                        assert_contains!(ctx.pack_stdout, "Requesting packages (packages changed)");
+                        assert_contains!(ctx.pack_stdout, "Adding `libgwenhywfar-data@5.9.0-1`");
+                        assert_contains!(ctx.pack_stdout, "`libgwenhywfar-data@5.9.0-1` from http://archive.ubuntu.com/ubuntu/pool/universe/libg/libgwenhywfar/libgwenhywfar-data_5.9.0-1_all.deb");
 
-                        assert_not_contains!(ctx.pack_stdout, "Adding libxmlsec1@1.2.33-1build2");
-                        assert_not_contains!(ctx.pack_stdout, "Downloading and extracting libxmlsec1");
+                        assert_not_contains!(ctx.pack_stdout, "Adding `libxmlsec1@1.2.33-1build2`");
+                        assert_not_contains!(ctx.pack_stdout, "`libxmlsec1@1.2.33-1build2` from http://archive.ubuntu.com/ubuntu/pool/main/x/xmlsec1/libxmlsec1_1.2.33-1build2_amd64.deb");
                     }
                     ("heroku/builder:24", "amd64") => {
-                        assert_contains!(ctx.pack_stdout, "Adding libgwenhywfar-data@5.10.2-2.1build4");
-                        assert_contains!(ctx.pack_stdout, "Downloading and extracting libgwenhywfar-data");
+                        assert_contains!(ctx.pack_stdout, "Requesting packages (packages changed)");
+                        assert_contains!(ctx.pack_stdout, "Adding `libgwenhywfar-data@5.10.2-2.1build4`");
+                        assert_contains!(ctx.pack_stdout, "`libgwenhywfar-data@5.10.2-2.1build4` from http://archive.ubuntu.com/ubuntu/pool/universe/libg/libgwenhywfar/libgwenhywfar-data_5.10.2-2.1build4_all.deb");
 
-                        assert_not_contains!(ctx.pack_stdout, "Adding libxmlsec1t64@1.2.39-5build2");
-                        assert_not_contains!(ctx.pack_stdout, "Downloading and extracting libxmlsec1t64");
+                        assert_not_contains!(ctx.pack_stdout, "Adding `libxmlsec1t64@1.2.39-5build2`");
+                        assert_not_contains!(ctx.pack_stdout, "`libxmlsec1t64@1.2.39-5build2` from http://archive.ubuntu.com/ubuntu/pool/main/x/xmlsec1/libxmlsec1t64@1.2.39-5build2_amd64.deb");
                     }
                     ("heroku/builder:24", "arm64") => {
+                        assert_contains!(ctx.pack_stdout, "Requesting packages (packages changed)");
                         assert_contains!(ctx.pack_stdout, "Adding libgwenhywfar-data@5.10.2-2.1build4");
                         assert_contains!(ctx.pack_stdout, "Downloading and extracting libgwenhywfar-data");
 
@@ -443,7 +495,7 @@ fn geo_buildpack_use_case() {
     if get_integration_test_builder().as_str() != "heroku/builder:22" {
         return;
     }
-    // this test is supposed to validate that this buildpack can be an effectively replacement for the
+    // this test is supposed to validate that this buildpack can be an effective replacement for the
     // heroku-geo-buildpack (https://github.com/heroku/heroku-geo-buildpack) and allow a language like
     // Python to bind to libgdal-dev headers
     integration_test_with_config(

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -93,29 +93,14 @@ fn test_general_usage_output() {
                 assert_contains!(ctx.pack_stdout, "Adding `libgwenhywfar79@5.9.0-1`");
                 assert_contains!(ctx.pack_stdout, "Adding `libgwenhywfar-data@5.9.0-1` [from libgwenhywfar79]");
                 assert_contains!(ctx.pack_stdout, "Determining install requirements for requested package `libgwenhywfar-data`");
-                assert_contains!(ctx.pack_stdout, "Nothing to add");
+                assert_contains!(ctx.pack_stdout, "Skipping `libgwenhywfar-data` because `libgwenhywfar-data@5.9.0-1` was already installed as a dependency of `libgwenhywfar79`");
                 assert_contains!(ctx.pack_stdout, "Determining install requirements for requested package `xmlsec1`");
                 assert_contains!(ctx.pack_stdout, "Adding `xmlsec1@1.2.33-1build2`");
                 assert_contains!(ctx.pack_stdout, "Determining install requirements for requested package `wget`");
-                assert_contains!(ctx.pack_stdout, "Nothing to add");
+                assert_contains_match!(ctx.pack_stdout, "Skipping `wget` because `wget@1.21.2-.*` is already installed on the system");
                 assert_contains!(ctx.pack_stdout, "Determining install requirements for requested package `libvips`");
-                assert_contains!(ctx.pack_stdout, "Nothing to add");
-                assert_contains!(
-                    ctx.pack_stdout,
-                    "! Skipping `libgwenhywfar-data` because `libgwenhywfar-data@5.9.0-1` was already installed as a dependency of `libgwenhywfar79` (consider removing `libgwenhywfar-data` from your project.toml configuration for this buildpack)"
-                );
-                assert_contains_match!(
-                    ctx.pack_stdout,
-                    "! Skipping `wget` because `wget@1.21.2-.*` is already installed on the system \\(consider removing `wget` from your project.toml configuration for this buildpack\\)"
-                );
-                assert_contains!(
-                    ctx.pack_stdout,
-                    "! Virtual package `libvips` is provided by `libvips42@8.12.1-1build1` (consider replacing `libvips` with `libvips42` in your project.toml configuration for this buildpack)"
-                );
-                assert_contains!(
-                    ctx.pack_stdout,
-                    "! Skipping `libvips42` because `libvips42@8.12.1-1build1` is already installed on the system (consider removing `libvips42` from your project.toml configuration for this buildpack)"
-                );
+                assert_contains!(ctx.pack_stdout, "Virtual package `libvips` is provided by `libvips42@8.12.1-1build1`");
+                assert_contains!(ctx.pack_stdout, "Skipping `libvips42` because `libvips42@8.12.1-1build1` is already installed on the system");
 
                 assert_contains!(ctx.pack_stdout, "## Installing packages");
                 assert_contains!(ctx.pack_stdout, "Requesting packages");
@@ -157,36 +142,19 @@ fn test_general_usage_output() {
                 assert_contains!(ctx.pack_stdout, "## Determining packages to install");
                 assert_contains!(ctx.pack_stdout, "Collecting system install information");
                 assert_contains!(ctx.pack_stdout, "Determining install requirements for requested package `libgwenhywfar79`");
-                assert_contains!(ctx.pack_stdout, "Adding `libgwenhywfar79t64@5.10.2-2.1build4`");
-                assert_contains!(ctx.pack_stdout, "Adding `libgwenhywfar-data@5.10.2-2.1build4` [from libgwenhywfar79t64]");
+                assert_contains!(ctx.pack_stdout, "Virtual package `libgwenhywfar79` is provided by `libgwenhywfar79t64@5.10.2-2.1build4`");
+                assert_contains!(ctx.pack_stdout, "Adding `libgwenhywfar79t64@5.10.2-2.1build4` [from libgwenhywfar79]");
+                assert_contains!(ctx.pack_stdout, "Adding `libgwenhywfar-data@5.10.2-2.1build4` [from libgwenhywfar79t64 ← libgwenhywfar79]");
+
                 assert_contains!(ctx.pack_stdout, "Determining install requirements for requested package `libgwenhywfar-data`");
-                assert_contains!(ctx.pack_stdout, "Nothing to add");
+                assert_contains!(ctx.pack_stdout, "Skipping `libgwenhywfar-data` because `libgwenhywfar-data@5.10.2-2.1build4` was already installed as a dependency of `libgwenhywfar79`");
                 assert_contains!(ctx.pack_stdout, "Determining install requirements for requested package `xmlsec1`");
                 assert_contains!(ctx.pack_stdout, "Adding `xmlsec1@1.2.39-5build2`");
                 assert_contains!(ctx.pack_stdout, "Determining install requirements for requested package `wget`");
-                assert_contains!(ctx.pack_stdout, "Nothing to add");
+                assert_contains_match!(ctx.pack_stdout, "Skipping `wget` because `wget@1.21.4-.*` is already installed on the system");
                 assert_contains!(ctx.pack_stdout, "Determining install requirements for requested package `libvips`");
-                assert_contains!(ctx.pack_stdout, "Nothing to add");
-                assert_contains!(
-                    ctx.pack_stdout,
-                    "! Virtual package `libgwenhywfar79` is provided by `libgwenhywfar79t64@5.10.2-2.1build4` (consider replacing `libgwenhywfar79` with `libgwenhywfar79t64` in your project.toml configuration for this buildpack)"
-                );
-                assert_contains!(
-                    ctx.pack_stdout,
-                    "! Skipping `libgwenhywfar-data` because `libgwenhywfar-data@5.10.2-2.1build4` was already installed as a dependency of `libgwenhywfar79t64` (consider removing `libgwenhywfar-data` from your project.toml configuration for this buildpack)"
-                );
-                assert_contains_match!(
-                    ctx.pack_stdout,
-                    "! Skipping `wget` because `wget@1.21.4-.*` is already installed on the system \\(consider removing `wget` from your project.toml configuration for this buildpack\\)"
-                );
-                assert_contains!(
-                    ctx.pack_stdout,
-                    "! Virtual package `libvips` is provided by `libvips42t64@8.15.1-1.1build4` (consider replacing `libvips` with `libvips42t64` in your project.toml configuration for this buildpack)"
-                );
-                assert_contains!(
-                    ctx.pack_stdout,
-                    "! Skipping `libvips42t64` because `libvips42t64@8.15.1-1.1build4` is already installed on the system (consider removing `libvips42t64` from your project.toml configuration for this buildpack)"
-                );
+                assert_contains!(ctx.pack_stdout, "Virtual package `libvips` is provided by `libvips42t64@8.15.1-1.1build4`");
+                assert_contains!(ctx.pack_stdout, "Skipping `libvips42t64` because `libvips42t64@8.15.1-1.1build4` is already installed on the system");
 
                 assert_contains!(ctx.pack_stdout, "## Installing packages");
                 assert_contains!(ctx.pack_stdout, "Requesting packages");
@@ -228,36 +196,18 @@ fn test_general_usage_output() {
                 assert_contains!(ctx.pack_stdout, "## Determining packages to install");
                 assert_contains!(ctx.pack_stdout, "Collecting system install information");
                 assert_contains!(ctx.pack_stdout, "Determining install requirements for requested package `libgwenhywfar79`");
-                assert_contains!(ctx.pack_stdout, "Adding `libgwenhywfar79t64@5.10.2-2.1build4`");
-                assert_contains!(ctx.pack_stdout, "Adding `libgwenhywfar-data@5.10.2-2.1build4` [from libgwenhywfar79t64]");
+                assert_contains!(ctx.pack_stdout, "Virtual package `libgwenhywfar79` is provided by `libgwenhywfar79t64@5.10.2-2.1build4`");
+                assert_contains!(ctx.pack_stdout, "Adding `libgwenhywfar79t64@5.10.2-2.1build4` [from libgwenhywfar79]");
+                assert_contains!(ctx.pack_stdout, "Adding `libgwenhywfar-data@5.10.2-2.1build4` [from libgwenhywfar79t64 ← libgwenhywfar79]");
                 assert_contains!(ctx.pack_stdout, "Determining install requirements for requested package `libgwenhywfar-data`");
-                assert_contains!(ctx.pack_stdout, "Nothing to add");
+                assert_contains!(ctx.pack_stdout, "Skipping `libgwenhywfar-data` because `libgwenhywfar-data@5.10.2-2.1build4` was already installed as a dependency of `libgwenhywfar79`");
                 assert_contains!(ctx.pack_stdout, "Determining install requirements for requested package `xmlsec1`");
                 assert_contains!(ctx.pack_stdout, "Adding `xmlsec1@1.2.39-5build2`");
                 assert_contains!(ctx.pack_stdout, "Determining install requirements for requested package `wget`");
-                assert_contains!(ctx.pack_stdout, "Nothing to add");
+                assert_contains_match!(ctx.pack_stdout, "Skipping `wget` because `wget@1.21.4-.*` is already installed on the system");
                 assert_contains!(ctx.pack_stdout, "Determining install requirements for requested package `libvips`");
-                assert_contains!(ctx.pack_stdout, "Nothing to add");
-                assert_contains!(
-                    ctx.pack_stdout,
-                    "! Virtual package `libgwenhywfar79` is provided by `libgwenhywfar79t64@5.10.2-2.1build4` (consider replacing `libgwenhywfar79` with `libgwenhywfar79t64` in your project.toml configuration for this buildpack)"
-                );
-                assert_contains!(
-                    ctx.pack_stdout,
-                    "! Skipping `libgwenhywfar-data` because `libgwenhywfar-data@5.10.2-2.1build4` was already installed as a dependency of `libgwenhywfar79t64` (consider removing `libgwenhywfar-data` from your project.toml configuration for this buildpack)"
-                );
-                assert_contains_match!(
-                    ctx.pack_stdout,
-                    "! Skipping `wget` because `wget@1.21.4-.*` is already installed on the system \\(consider removing `wget` from your project.toml configuration for this buildpack\\)"
-                );
-                assert_contains!(
-                    ctx.pack_stdout,
-                    "! Virtual package `libvips` is provided by `libvips42t64@8.15.1-1.1build4` (consider replacing `libvips` with `libvips42t64` in your project.toml configuration for this buildpack)"
-                );
-                assert_contains!(
-                    ctx.pack_stdout,
-                    "! Skipping `libvips42t64` because `libvips42t64@8.15.1-1.1build4` is already installed on the system (consider removing `libvips42t64` from your project.toml configuration for this buildpack)"
-                );
+                assert_contains!(ctx.pack_stdout, "Virtual package `libvips` is provided by `libvips42t64@8.15.1-1.1build4`");
+                assert_contains!(ctx.pack_stdout, "Skipping `libvips42t64` because `libvips42t64@8.15.1-1.1build4` is already installed on the system");
 
                 assert_contains!(ctx.pack_stdout, "## Installing packages");
                 assert_contains!(ctx.pack_stdout, "Requesting packages");

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -430,8 +430,8 @@ fn test_cache_invalidated_when_configuration_changes() {
                 }
                 ("heroku/builder:24", "arm64") => {
                     assert_contains!(ctx.pack_stdout, "Requesting packages");
-                    assert_contains!(ctx.pack_stdout, "Adding libxmlsec1t64@1.2.39-5build2");
-                    assert_contains!(ctx.pack_stdout, "Downloading and extracting libxmlsec1t64");
+                    assert_contains!(ctx.pack_stdout, "Adding `libxmlsec1t64@1.2.39-5build2`");
+                    assert_contains!(ctx.pack_stdout, "`libxmlsec1t64@1.2.39-5build2` from http://ports.ubuntu.com/ubuntu-ports/pool/main/x/xmlsec1/libxmlsec1t64_1.2.39-5build2_arm64.deb");
                 }
                 _ => panic_unsupported_test_configuration(),
             }
@@ -509,7 +509,7 @@ fn geo_buildpack_use_case() {
                 .buildpacks(vec![BuildpackReference::CurrentCrate, BuildpackReference::Other("heroku/python".to_string())]);
         },
         |ctx| {
-            assert_contains!(ctx.pack_stdout, "Adding libgdal-dev@3.4.1");
+            assert_contains!(ctx.pack_stdout, "Adding `libgdal-dev@3.4.1");
             assert_contains!(ctx.pack_stdout, "Collecting GDAL==3.4.1 (from -r requirements.txt (line 1))");
             assert_contains!(ctx.pack_stdout, "Successfully built GDAL");
             assert_contains!(ctx.pack_stdout, "Successfully installed GDAL-3.4.1");

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -200,56 +200,75 @@ fn test_general_usage_output() {
                 assert_contains!(ctx.pack_stdout, "/layers/heroku_deb-packages/packages/usr/lib/x86_64-linux-gnu/libgwenhywfar.so");
             }
             ("heroku/builder:24", "arm64") => {
-                assert_contains!(ctx.pack_stdout, "## Distribution Info");
-
-                assert_contains!(ctx.pack_stdout, "- Name: ubuntu");
-                assert_contains!(ctx.pack_stdout, "- Version: 24.04");
-                assert_contains!(ctx.pack_stdout, "- Codename: noble");
-                assert_contains!(ctx.pack_stdout, "- Architecture: arm64");
+                assert_contains!(ctx.pack_stdout, "Distribution Info");
+                assert_contains!(ctx.pack_stdout, "Name: ubuntu");
+                assert_contains!(ctx.pack_stdout, "Version: 24.04");
+                assert_contains!(ctx.pack_stdout, "Codename: noble");
+                assert_contains!(ctx.pack_stdout, "Architecture: arm64");
 
                 assert_contains!(ctx.pack_stdout, "## Creating package index");
-
-                assert_contains_match!(ctx.pack_stdout, r"\[GET\] http://ports.ubuntu.com/ubuntu-ports/dists/noble/InRelease");
-                assert_contains_match!(ctx.pack_stdout, r"\[GET\] http://ports.ubuntu.com/ubuntu-ports/dists/noble/main/binary-arm64/by-hash/SHA256/[0-9a-f]+$");
-                assert_contains_match!(ctx.pack_stdout, r"\[GET\] http://ports.ubuntu.com/ubuntu-ports/dists/noble/universe/binary-arm64/by-hash/SHA256/[0-9a-f]+$");
-                assert_contains_match!(ctx.pack_stdout, r"\[GET\] http://ports.ubuntu.com/ubuntu-ports/dists/noble-security/InRelease");
-                assert_contains_match!(ctx.pack_stdout, r"\[GET\] http://ports.ubuntu.com/ubuntu-ports/dists/noble-security/main/binary-arm64/by-hash/SHA256/[0-9a-f]+$");
-                assert_contains_match!(ctx.pack_stdout, r"\[GET\] http://ports.ubuntu.com/ubuntu-ports/dists/noble-security/universe/binary-arm64/by-hash/SHA256/[0-9a-f]+$");
-                assert_contains_match!(ctx.pack_stdout, r"\[GET\] http://ports.ubuntu.com/ubuntu-ports/dists/noble-updates/InRelease");
-                assert_contains_match!(ctx.pack_stdout, r"\[GET\] http://ports.ubuntu.com/ubuntu-ports/dists/noble-updates/main/binary-arm64/by-hash/SHA256/[0-9a-f]+$");
-                assert_contains_match!(ctx.pack_stdout, r"\[GET\] http://ports.ubuntu.com/ubuntu-ports/dists/noble-updates/universe/binary-arm64/by-hash/SHA256/[0-9a-f]+$");
-
-                assert_contains!(ctx.pack_stdout, "Processing package files...");
-                assert_contains_match!(ctx.pack_stdout, r"Indexed \d+ packages \(\d+ms\)");
+                assert_contains!(ctx.pack_stdout, "Package sources");
+                assert_contains!(ctx.pack_stdout, "http://ports.ubuntu.com/ubuntu-ports noble [main, universe]");
+                assert_contains!(ctx.pack_stdout, "http://ports.ubuntu.com/ubuntu-ports noble-updates [main, universe]");
+                assert_contains!(ctx.pack_stdout, "http://ports.ubuntu.com/ubuntu-ports noble-security [main, universe]");
+                assert_contains!(ctx.pack_stdout, "Updating");
+                assert_contains_match!(ctx.pack_stdout, r"Downloaded release file http://ports.ubuntu.com/ubuntu-ports/dists/noble/InRelease");
+                assert_contains_match!(ctx.pack_stdout, r"Downloaded package index http://ports.ubuntu.com/ubuntu-ports/dists/noble/main/binary-arm64/by-hash/SHA256/[0-9a-f]+$");
+                assert_contains_match!(ctx.pack_stdout, r"Downloaded package index http://ports.ubuntu.com/ubuntu-ports/dists/noble/universe/binary-arm64/by-hash/SHA256/[0-9a-f]+$");
+                assert_contains_match!(ctx.pack_stdout, r"Downloaded release file http://ports.ubuntu.com/ubuntu-ports/dists/noble-security/InRelease");
+                assert_contains_match!(ctx.pack_stdout, r"Downloaded package index http://ports.ubuntu.com/ubuntu-ports/dists/noble-security/main/binary-arm64/by-hash/SHA256/[0-9a-f]+$");
+                assert_contains_match!(ctx.pack_stdout, r"Downloaded package index http://ports.ubuntu.com/ubuntu-ports/dists/noble-security/universe/binary-arm64/by-hash/SHA256/[0-9a-f]+$");
+                assert_contains_match!(ctx.pack_stdout, r"Downloaded release file http://ports.ubuntu.com/ubuntu-ports/dists/noble-updates/InRelease");
+                assert_contains_match!(ctx.pack_stdout, r"Downloaded package index http://ports.ubuntu.com/ubuntu-ports/dists/noble-updates/main/binary-arm64/by-hash/SHA256/[0-9a-f]+$");
+                assert_contains_match!(ctx.pack_stdout, r"Downloaded package index http://ports.ubuntu.com/ubuntu-ports/dists/noble-updates/universe/binary-arm64/by-hash/SHA256/[0-9a-f]+$");
+                assert_contains!(ctx.pack_stdout, "Building package index");
+                assert_contains!(ctx.pack_stdout, "Processing package files");
+                assert_contains_match!(ctx.pack_stdout, r"Indexed \d+ packages");
 
                 assert_contains!(ctx.pack_stdout, "## Determining packages to install");
-
+                assert_contains!(ctx.pack_stdout, "Collecting system install information");
+                assert_contains!(ctx.pack_stdout, "Determining install requirements for requested package `libgwenhywfar79`");
+                assert_contains!(ctx.pack_stdout, "Adding `libgwenhywfar79t64@5.10.2-2.1build4`");
+                assert_contains!(ctx.pack_stdout, "Adding `libgwenhywfar-data@5.10.2-2.1build4` [from libgwenhywfar79t64]");
+                assert_contains!(ctx.pack_stdout, "Determining install requirements for requested package `libgwenhywfar-data`");
+                assert_contains!(ctx.pack_stdout, "Nothing to add");
+                assert_contains!(ctx.pack_stdout, "Determining install requirements for requested package `xmlsec1`");
+                assert_contains!(ctx.pack_stdout, "Adding `xmlsec1@1.2.39-5build2`");
+                assert_contains!(ctx.pack_stdout, "Determining install requirements for requested package `wget`");
+                assert_contains!(ctx.pack_stdout, "Nothing to add");
+                assert_contains!(ctx.pack_stdout, "Determining install requirements for requested package `libvips`");
+                assert_contains!(ctx.pack_stdout, "Nothing to add");
                 assert_contains!(
                     ctx.pack_stdout,
-                    "! Virtual package libgwenhywfar79 is provided by libgwenhywfar79t64@5.10.2-2.1build4 (consider replacing libgwenhywfar79 for libgwenhywfar79t64 in your project.toml configuration for this buildpack)"
+                    "! Virtual package `libgwenhywfar79` is provided by `libgwenhywfar79t64@5.10.2-2.1build4` (consider replacing `libgwenhywfar79` with `libgwenhywfar79t64` in your project.toml configuration for this buildpack)"
                 );
-                assert_contains!(ctx.pack_stdout, "Adding libgwenhywfar79t64@5.10.2-2.1build4");
-                assert_contains!(ctx.pack_stdout, "Adding libgwenhywfar-data@5.10.2-2.1build4 [from libgwenhywfar79t64]");
                 assert_contains!(
                     ctx.pack_stdout,
-                    "! Skipping libgwenhywfar-data because libgwenhywfar-data@5.10.2-2.1build4 was already installed as a dependency of libgwenhywfar79t64 (consider removing libgwenhywfar-data from your project.toml configuration for this buildpack)"
+                    "! Skipping `libgwenhywfar-data` because `libgwenhywfar-data@5.10.2-2.1build4` was already installed as a dependency of `libgwenhywfar79t64` (consider removing `libgwenhywfar-data` from your project.toml configuration for this buildpack)"
                 );
-                assert_contains!(ctx.pack_stdout, "Adding xmlsec1@1.2.39-5build2");
-                assert_contains_match!(ctx.pack_stdout, "! Skipping wget because wget@1.21.4-.* is already installed on the system \\(consider removing wget from your project.toml configuration for this buildpack\\)");
-                assert_contains!(
+                assert_contains_match!(
                     ctx.pack_stdout,
-                    "! Virtual package libvips is provided by libvips42t64@8.15.1-1.1build4 (consider replacing libvips for libvips42t64 in your project.toml configuration for this buildpack)"
+                    "! Skipping `wget` because `wget@1.21.4-.*` is already installed on the system \\(consider removing `wget` from your project.toml configuration for this buildpack\\)"
                 );
                 assert_contains!(
                     ctx.pack_stdout,
-                    "! Skipping libvips42t64 because libvips42t64@8.15.1-1.1build4 is already installed on the system (consider removing libvips42t64 from your project.toml configuration for this buildpack)"
+                    "! Virtual package `libvips` is provided by `libvips42t64@8.15.1-1.1build4` (consider replacing `libvips` with `libvips42t64` in your project.toml configuration for this buildpack)"
+                );
+                assert_contains!(
+                    ctx.pack_stdout,
+                    "! Skipping `libvips42t64` because `libvips42t64@8.15.1-1.1build4` is already installed on the system (consider removing `libvips42t64` from your project.toml configuration for this buildpack)"
                 );
 
                 assert_contains!(ctx.pack_stdout, "## Installing packages");
-
-                assert_contains!(ctx.pack_stdout, "Downloading and extracting libgwenhywfar79t64");
-                assert_contains!(ctx.pack_stdout, "Downloading and extracting xmlsec1");
-                assert_contains!(ctx.pack_stdout, "Downloading and extracting libgwenhywfar-data");
+                assert_contains!(ctx.pack_stdout, "Requesting packages");
+                assert_contains!(ctx.pack_stdout, "`libgwenhywfar79t64@5.10.2-2.1build4` from http://ports.ubuntu.com/ubuntu-ports/pool/universe/libg/libgwenhywfar/libgwenhywfar79t64_5.10.2-2.1build4_arm64.deb");
+                assert_contains!(ctx.pack_stdout, "`libgwenhywfar-data@5.10.2-2.1build4` from http://ports.ubuntu.com/ubuntu-ports/pool/universe/libg/libgwenhywfar/libgwenhywfar-data_5.10.2-2.1build4_all.deb");
+                assert_contains!(ctx.pack_stdout, "`xmlsec1@1.2.39-5build2` from http://ports.ubuntu.com/ubuntu-ports/pool/main/x/xmlsec1/xmlsec1_1.2.39-5build2_arm64.deb");
+                assert_contains!(ctx.pack_stdout, "Downloading");
+                assert_contains!(ctx.pack_stdout, "Installation complete");
+                assert_contains!(ctx.pack_stdout, "Layer file listing");
+                assert_contains!(ctx.pack_stdout, "/layers/heroku_deb-packages/packages/usr/bin/xmlsec1");
+                assert_contains!(ctx.pack_stdout, "/layers/heroku_deb-packages/packages/usr/lib/aarch64-linux-gnu/libgwenhywfar.so");
             }
             _ => panic_unsupported_test_configuration(),
         }
@@ -298,19 +317,20 @@ fn test_general_usage_output_on_rebuild() {
                     assert_contains!(ctx.pack_stdout, "`xmlsec1@1.2.39-5build2`");
                 }
                 ("heroku/builder:24", "arm64") => {
-                    assert_contains_match!(ctx.pack_stdout, r"\[CACHED\] http://ports.ubuntu.com/ubuntu-ports/dists/noble/InRelease");
-                    assert_contains_match!(ctx.pack_stdout, r"\[CACHED\] http://ports.ubuntu.com/ubuntu-ports/dists/noble/main/binary-arm64/by-hash/SHA256/[0-9a-f]+$");
-                    assert_contains_match!(ctx.pack_stdout, r"\[CACHED\] http://ports.ubuntu.com/ubuntu-ports/dists/noble/universe/binary-arm64/by-hash/SHA256/[0-9a-f]+$");
-                    assert_contains_match!(ctx.pack_stdout, r"\[CACHED\] http://ports.ubuntu.com/ubuntu-ports/dists/noble-security/InRelease");
-                    assert_contains_match!(ctx.pack_stdout, r"\[CACHED\] http://ports.ubuntu.com/ubuntu-ports/dists/noble-security/main/binary-arm64/by-hash/SHA256/[0-9a-f]+$");
-                    assert_contains_match!(ctx.pack_stdout, r"\[CACHED\] http://ports.ubuntu.com/ubuntu-ports/dists/noble-security/universe/binary-arm64/by-hash/SHA256/[0-9a-f]+$");
-                    assert_contains_match!(ctx.pack_stdout, r"\[CACHED\] http://ports.ubuntu.com/ubuntu-ports/dists/noble-updates/InRelease");
-                    assert_contains_match!(ctx.pack_stdout, r"\[CACHED\] http://ports.ubuntu.com/ubuntu-ports/dists/noble-updates/main/binary-arm64/by-hash/SHA256/[0-9a-f]+$");
-                    assert_contains_match!(ctx.pack_stdout, r"\[CACHED\] http://ports.ubuntu.com/ubuntu-ports/dists/noble-updates/universe/binary-arm64/by-hash/SHA256/[0-9a-f]+$");
+                    assert_contains_match!(ctx.pack_stdout, r"Restored release file from cache \(http://ports.ubuntu.com/ubuntu-ports/dists/noble/InRelease\)");
+                    assert_contains_match!(ctx.pack_stdout, r"Restored package index from cache \(http://ports.ubuntu.com/ubuntu-ports/dists/noble/main/binary-arm64/by-hash/SHA256/[0-9a-f]+\)");
+                    assert_contains_match!(ctx.pack_stdout, r"Restored package index from cache \(http://ports.ubuntu.com/ubuntu-ports/dists/noble/universe/binary-arm64/by-hash/SHA256/[0-9a-f]+\)");
+                    assert_contains_match!(ctx.pack_stdout, r"Restored release file from cache \(http://ports.ubuntu.com/ubuntu-ports/dists/noble-security/InRelease\)");
+                    assert_contains_match!(ctx.pack_stdout, r"Restored package index from cache \(http://ports.ubuntu.com/ubuntu-ports/dists/noble-security/main/binary-arm64/by-hash/SHA256/[0-9a-f]+\)");
+                    assert_contains_match!(ctx.pack_stdout, r"Restored package index from cache \(http://ports.ubuntu.com/ubuntu-ports/dists/noble-security/universe/binary-arm64/by-hash/SHA256/[0-9a-f]+\)");
+                    assert_contains_match!(ctx.pack_stdout, r"Restored release file from cache \(http://ports.ubuntu.com/ubuntu-ports/dists/noble-updates/InRelease\)");
+                    assert_contains_match!(ctx.pack_stdout, r"Restored package index from cache \(http://ports.ubuntu.com/ubuntu-ports/dists/noble-updates/main/binary-arm64/by-hash/SHA256/[0-9a-f]+\)");
+                    assert_contains_match!(ctx.pack_stdout, r"Restored package index from cache \(http://ports.ubuntu.com/ubuntu-ports/dists/noble-updates/universe/binary-arm64/by-hash/SHA256/[0-9a-f]+\)");
 
-                    assert_contains!(ctx.pack_stdout, "Restoring xmlsec1 from cache");
-                    assert_contains!(ctx.pack_stdout, "Restoring libgwenhywfar-data from cache");
-                    assert_contains!(ctx.pack_stdout, "Restoring libgwenhywfar79t64 from cache");
+                    assert_contains!(ctx.pack_stdout, "Restoring packages from cache");
+                    assert_contains!(ctx.pack_stdout, "Restoring `xmlsec1@1.2.39-5build2` from cache");
+                    assert_contains!(ctx.pack_stdout, "Restoring `libgwenhywfar-data@5.10.2-2.1build4` from cache");
+                    assert_contains!(ctx.pack_stdout, "Restoring `libgwenhywfar79t64@5.10.2-2.1build4` from cache");
                 }
                 _ => panic_unsupported_test_configuration(),
             }
@@ -432,6 +452,9 @@ fn test_cache_invalidated_when_configuration_changes() {
                     assert_contains!(ctx.pack_stdout, "Requesting packages");
                     assert_contains!(ctx.pack_stdout, "Adding `libxmlsec1t64@1.2.39-5build2`");
                     assert_contains!(ctx.pack_stdout, "`libxmlsec1t64@1.2.39-5build2` from http://ports.ubuntu.com/ubuntu-ports/pool/main/x/xmlsec1/libxmlsec1t64_1.2.39-5build2_arm64.deb");
+
+                    assert_not_contains!(ctx.pack_stdout, "Adding `libgwenhywfar-data@5.10.2-2.1build4`");
+                    assert_not_contains!(ctx.pack_stdout, "`libgwenhywfar-data@5.10.2-2.1build4` from http://ports.ubuntu.com/ubuntu-ports/pool/universe/libg/libgwenhywfar/libgwenhywfar-data_5.10.2-2.1build4_all.deb");
                 }
                 _ => panic_unsupported_test_configuration(),
             }
@@ -460,11 +483,11 @@ fn test_cache_invalidated_when_configuration_changes() {
                     }
                     ("heroku/builder:24", "arm64") => {
                         assert_contains!(ctx.pack_stdout, "Requesting packages (packages changed)");
-                        assert_contains!(ctx.pack_stdout, "Adding libgwenhywfar-data@5.10.2-2.1build4");
-                        assert_contains!(ctx.pack_stdout, "Downloading and extracting libgwenhywfar-data");
+                        assert_contains!(ctx.pack_stdout, "Adding `libgwenhywfar-data@5.10.2-2.1build4`");
+                        assert_contains!(ctx.pack_stdout, "`libgwenhywfar-data@5.10.2-2.1build4` from http://ports.ubuntu.com/ubuntu-ports/pool/universe/libg/libgwenhywfar/libgwenhywfar-data_5.10.2-2.1build4_all.deb");
 
-                        assert_not_contains!(ctx.pack_stdout, "Adding libxmlsec1t64@1.2.39-5build2");
-                        assert_not_contains!(ctx.pack_stdout, "Downloading and extracting libxmlsec1t64");
+                        assert_not_contains!(ctx.pack_stdout, "Adding `libxmlsec1t64@1.2.39-5build2`");
+                        assert_not_contains!(ctx.pack_stdout, "`libxmlsec1t64@1.2.39-5build2` from http://ports.ubuntu.com/ubuntu-ports/pool/main/x/xmlsec1/libxmlsec1t64_1.2.39-5build2_arm64.deb");
                     }
                     _ => panic_unsupported_test_configuration(),
                 },

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -328,9 +328,9 @@ fn test_general_usage_output_on_rebuild() {
                     assert_contains_match!(ctx.pack_stdout, r"Restored package index from cache \(http://ports.ubuntu.com/ubuntu-ports/dists/noble-updates/universe/binary-arm64/by-hash/SHA256/[0-9a-f]+\)");
 
                     assert_contains!(ctx.pack_stdout, "Restoring packages from cache");
-                    assert_contains!(ctx.pack_stdout, "Restoring `xmlsec1@1.2.39-5build2` from cache");
-                    assert_contains!(ctx.pack_stdout, "Restoring `libgwenhywfar-data@5.10.2-2.1build4` from cache");
-                    assert_contains!(ctx.pack_stdout, "Restoring `libgwenhywfar79t64@5.10.2-2.1build4` from cache");
+                    assert_contains!(ctx.pack_stdout, "`libgwenhywfar79t64@5.10.2-2.1build4`");
+                    assert_contains!(ctx.pack_stdout, "`libgwenhywfar-data@5.10.2-2.1build4`");
+                    assert_contains!(ctx.pack_stdout, "`xmlsec1@1.2.39-5build2`");
                 }
                 _ => panic_unsupported_test_configuration(),
             }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -109,9 +109,10 @@ fn test_general_usage_output() {
                 assert_contains!(ctx.pack_stdout, "`xmlsec1@1.2.33-1build2` from http://archive.ubuntu.com/ubuntu/pool/main/x/xmlsec1/xmlsec1_1.2.33-1build2_amd64.deb");
                 assert_contains!(ctx.pack_stdout, "Downloading");
                 assert_contains!(ctx.pack_stdout, "Installation complete");
-                assert_contains!(ctx.pack_stdout, "Layer file listing");
-                assert_contains!(ctx.pack_stdout, "/layers/heroku_deb-packages/packages/usr/bin/xmlsec1");
-                assert_contains!(ctx.pack_stdout, "/layers/heroku_deb-packages/packages/usr/lib/x86_64-linux-gnu/libgwenhywfar.so");
+
+                assert_not_contains!(ctx.pack_stdout, "Layer file listing");
+                assert_not_contains!(ctx.pack_stdout, "/layers/heroku_deb-packages/packages/usr/bin/xmlsec1");
+                assert_not_contains!(ctx.pack_stdout, "/layers/heroku_deb-packages/packages/usr/lib/x86_64-linux-gnu/libgwenhywfar.so");
             }
             ("heroku/builder:24", "amd64") => {
                 assert_contains!(ctx.pack_stdout, "Distribution Info");
@@ -163,9 +164,10 @@ fn test_general_usage_output() {
                 assert_contains!(ctx.pack_stdout, "`xmlsec1@1.2.39-5build2` from http://archive.ubuntu.com/ubuntu/pool/main/x/xmlsec1/xmlsec1_1.2.39-5build2_amd64.deb");
                 assert_contains!(ctx.pack_stdout, "Downloading");
                 assert_contains!(ctx.pack_stdout, "Installation complete");
-                assert_contains!(ctx.pack_stdout, "Layer file listing");
-                assert_contains!(ctx.pack_stdout, "/layers/heroku_deb-packages/packages/usr/bin/xmlsec1");
-                assert_contains!(ctx.pack_stdout, "/layers/heroku_deb-packages/packages/usr/lib/x86_64-linux-gnu/libgwenhywfar.so");
+
+                assert_not_contains!(ctx.pack_stdout, "Layer file listing");
+                assert_not_contains!(ctx.pack_stdout, "/layers/heroku_deb-packages/packages/usr/bin/xmlsec1");
+                assert_not_contains!(ctx.pack_stdout, "/layers/heroku_deb-packages/packages/usr/lib/x86_64-linux-gnu/libgwenhywfar.so");
             }
             ("heroku/builder:24", "arm64") => {
                 assert_contains!(ctx.pack_stdout, "Distribution Info");
@@ -216,13 +218,36 @@ fn test_general_usage_output() {
                 assert_contains!(ctx.pack_stdout, "`xmlsec1@1.2.39-5build2` from http://ports.ubuntu.com/ubuntu-ports/pool/main/x/xmlsec1/xmlsec1_1.2.39-5build2_arm64.deb");
                 assert_contains!(ctx.pack_stdout, "Downloading");
                 assert_contains!(ctx.pack_stdout, "Installation complete");
-                assert_contains!(ctx.pack_stdout, "Layer file listing");
-                assert_contains!(ctx.pack_stdout, "/layers/heroku_deb-packages/packages/usr/bin/xmlsec1");
-                assert_contains!(ctx.pack_stdout, "/layers/heroku_deb-packages/packages/usr/lib/aarch64-linux-gnu/libgwenhywfar.so");
+
+                assert_not_contains!(ctx.pack_stdout, "Layer file listing");
+                assert_not_contains!(ctx.pack_stdout, "/layers/heroku_deb-packages/packages/usr/bin/xmlsec1");
+                assert_not_contains!(ctx.pack_stdout, "/layers/heroku_deb-packages/packages/usr/lib/aarch64-linux-gnu/libgwenhywfar.so");
             }
             _ => panic_unsupported_test_configuration(),
         }
     });
+}
+
+#[test]
+#[ignore = "integration test"]
+#[allow(clippy::too_many_lines)]
+fn test_general_usage_output_when_buildpack_log_level_is_debug() {
+    integration_test_with_config(
+        "fixtures/general_usage",
+        |config| {
+            config.env("BP_LOG_LEVEL", "DEBUG");
+        },
+        |ctx| {
+            let multiarch_name = match get_integration_test_arch().as_str() {
+                "amd64" => "x86_64-linux-gnu",
+                "arm64" => "aarch64-linux-gnu",
+                _ => panic_unsupported_test_configuration(),
+            };
+            assert_contains!(ctx.pack_stdout, "Layer file listing");
+            assert_contains!(ctx.pack_stdout, "/layers/heroku_deb-packages/packages/usr/bin/xmlsec1");
+            assert_contains!(ctx.pack_stdout, &format!("/layers/heroku_deb-packages/packages/usr/lib/{multiarch_name}/libgwenhywfar.so"));
+        },
+    );
 }
 
 #[test]


### PR DESCRIPTION
Changed the output to use `bullet_stream` which required a bit of restructuring for how data gets passed around but, overall, I think this newer format is an improvement.

### Sample output

```sh
# Heroku .deb Packages (v0.0.1)

- Distribution Info
  - Name: ubuntu
  - Version: 24.04
  - Codename: noble
  - Architecture: amd64

## Creating package index

- Package sources
  - http://archive.ubuntu.com/ubuntu noble [main, universe]
  - http://archive.ubuntu.com/ubuntu noble-updates [main, universe]
  - http://security.ubuntu.com/ubuntu noble-security [main, universe]
  - Updating .................................................................................................... (1m 38s)
  - Downloaded release file http://security.ubuntu.com/ubuntu/dists/noble-security/InRelease
  - Downloaded package index http://security.ubuntu.com/ubuntu/dists/noble-security/main/binary-amd64/by-hash/SHA256/025d63f18731808063b54828d296b4e3703641eeebe1e7190c0ce3b908d51ae8
  - Downloaded package index http://security.ubuntu.com/ubuntu/dists/noble-security/universe/binary-amd64/by-hash/SHA256/f69d7e6f99da216f4ea40001faf008802d62a7169c17badad0c3a9113a9902f5
  - Downloaded release file http://archive.ubuntu.com/ubuntu/dists/noble-updates/InRelease
  - Downloaded package index http://archive.ubuntu.com/ubuntu/dists/noble-updates/main/binary-amd64/by-hash/SHA256/e0c9b15dfb6b1102ce75d2a303b9f53bd428078b73cf342bffbfde7815725eb9
  - Downloaded package index http://archive.ubuntu.com/ubuntu/dists/noble-updates/universe/binary-amd64/by-hash/SHA256/e00cd814cff3e32dde502d05231e93652a773bcc71dbe2771938252de94470da
  - Downloaded release file http://archive.ubuntu.com/ubuntu/dists/noble/InRelease
  - Downloaded package index http://archive.ubuntu.com/ubuntu/dists/noble/main/binary-amd64/by-hash/SHA256/e0d7e4cbb09d2aa7f9e104a1488817417bc9d85f3e5d9a21156a52ec641ae531
  - Downloaded package index http://archive.ubuntu.com/ubuntu/dists/noble/universe/binary-amd64/by-hash/SHA256/ce57756edcce0a5f7993ceb89057e1510148e04e3b85a066d780e4bc00485c8a
- Building package index
  - Processing package files ..... (2.6s)
  - Indexed 81275 packages

## Determining packages to install

- Collecting system install information
- Determining install requirements for requested package `libgwenhywfar79`
  - Adding `libgwenhywfar79t64@5.10.2-2.1build4`
  - Adding `libgwenhywfar-data@5.10.2-2.1build4` [from libgwenhywfar79t64]
- Determining install requirements for requested package `libgwenhywfar-data`
  - Nothing to add
- Determining install requirements for requested package `xmlsec1`
  - Adding `xmlsec1@1.2.39-5build2`
- Determining install requirements for requested package `wget`
  - Nothing to add
- Determining install requirements for requested package `libvips`
  - Nothing to add

! Virtual package `libgwenhywfar79` is provided by `libgwenhywfar79t64@5.10.2-2.1build4` (consider replacing `libgwenhywfar79` with `libgwenhywfar79t64` in your project.toml configuration for this buildpack)

! Skipping `libgwenhywfar-data` because `libgwenhywfar-data@5.10.2-2.1build4` was already installed as a dependency of `libgwenhywfar79t64` (consider removing `libgwenhywfar-data` from your project.toml configuration for this buildpack)

! Skipping `wget` because `wget@1.21.4-1ubuntu4.1` is already installed on the system (consider removing `wget` from your project.toml configuration for this buildpack)

! Virtual package `libvips` is provided by `libvips42t64@8.15.1-1.1build4` (consider replacing `libvips` with `libvips42t64` in your project.toml configuration for this buildpack)

! Skipping `libvips42t64` because `libvips42t64@8.15.1-1.1build4` is already installed on the system (consider removing `libvips42t64` from your project.toml configuration for this buildpack)

## Installing packages

- Requesting packages
  - `libgwenhywfar79t64@5.10.2-2.1build4` from http://archive.ubuntu.com/ubuntu/pool/universe/libg/libgwenhywfar/libgwenhywfar79t64_5.10.2-2.1build4_amd64.deb
  - `libgwenhywfar-data@5.10.2-2.1build4` from http://archive.ubuntu.com/ubuntu/pool/universe/libg/libgwenhywfar/libgwenhywfar-data_5.10.2-2.1build4_all.deb
  - `xmlsec1@1.2.39-5build2` from http://archive.ubuntu.com/ubuntu/pool/main/x/xmlsec1/xmlsec1_1.2.39-5build2_amd64.deb
  - Downloading ..... (2.5s)
- Installation complete
  - Layer file listing

      /layers/heroku_deb-packages/packages/usr/bin/xmlsec1
      /layers/heroku_deb-packages/packages/usr/share/locale/de/LC_MESSAGES/gwenhywfar.mo
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/struct_base.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/gwen_bindata.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/tree_base.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/uint16_t.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/gwen_multicache_type.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/uint16_t_array.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/gwen_param_list2.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/gwen_xmlnode_list2.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/uint32_t.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/int_base.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/int.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/gwen_buffer.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/char_ptr.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/gwen_multicache.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/char.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/list2_base.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/uint32_t_array.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/double_array.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/gwen_stringlist2.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/uint64_t.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/uint8_t.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/gwen_idlist64.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/char_array.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/double.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/gwen_date.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/gwen_xmlnode_list.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/int_array.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/gwen_param_tree.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/gwen_xmlnode.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/list1_base.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/gwen_param_list.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/gwen_param.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/gwen_db_node.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/tree2_base.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/idmap_base.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/gwen_time.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/typemaker2/c/uint8_t_array.tm2
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/dialogs/dlg_message.dlg
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/dialogs/dlg_progress.dlg
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/dialogs/dlg_showbox.dlg
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/dialogs/dlg_input.dlg
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/gwenbuild/builders/posix/tm2builder.gwb
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/gwenbuild/builders/posix/staticlib.gwb
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/gwenbuild/builders/posix/tmplib.gwb
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/gwenbuild/builders/posix/cbuilder.gwb
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/gwenbuild/builders/posix/sharedlib.gwb
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/gwenbuild/builders/posix/app.gwb
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/gwenbuild/builders/posix/cxxapp.gwb
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/gwenbuild/builders/posix/cxxbuilder.gwb
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/gwenbuild/builders/posix/module.gwb
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/gwenbuild/builders/posix/msgfmt.gwb
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/gwenbuild/builders/windows/tm2builder.gwb
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/gwenbuild/builders/windows/staticlib.gwb
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/gwenbuild/builders/windows/tmplib.gwb
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/gwenbuild/builders/windows/cbuilder.gwb
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/gwenbuild/builders/windows/sharedlib.gwb
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/gwenbuild/builders/windows/app.gwb
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/gwenbuild/builders/windows/cxxapp.gwb
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/gwenbuild/builders/windows/cxxbuilder.gwb
      /layers/heroku_deb-packages/packages/usr/share/gwenhywfar/gwenbuild/builders/windows/module.gwb
      /layers/heroku_deb-packages/packages/usr/share/doc/libgwenhywfar-data/copyright
      /layers/heroku_deb-packages/packages/usr/share/doc/libgwenhywfar-data/changelog.Debian.gz
      /layers/heroku_deb-packages/packages/usr/share/doc/libgwenhywfar79t64/copyright
      /layers/heroku_deb-packages/packages/usr/share/doc/libgwenhywfar79t64/changelog.Debian.gz
      /layers/heroku_deb-packages/packages/usr/share/doc/xmlsec1/copyright
      /layers/heroku_deb-packages/packages/usr/share/man/man1/xmlsec1.1.gz
      /layers/heroku_deb-packages/packages/usr/share/gwenbuild/templates/project.tmpl
      /layers/heroku_deb-packages/packages/usr/share/gwenbuild/templates/module.tmpl
      /layers/heroku_deb-packages/packages/usr/share/gwenbuild/templates/convlib.tmpl
      /layers/heroku_deb-packages/packages/usr/share/lintian/overrides/libgwenhywfar79t64
      /layers/heroku_deb-packages/packages/usr/lib/x86_64-linux-gnu/libgwengui-cpp.so.79.10.2
      /layers/heroku_deb-packages/packages/usr/lib/x86_64-linux-gnu/libgwenhywfar.so.79.10.2
      /layers/heroku_deb-packages/packages/usr/lib/x86_64-linux-gnu/gwenhywfar/plugins/79/configmgr/dir.xml
      /layers/heroku_deb-packages/packages/usr/lib/x86_64-linux-gnu/gwenhywfar/plugins/79/configmgr/dir.so
      /layers/heroku_deb-packages/packages/usr/lib/x86_64-linux-gnu/gwenhywfar/plugins/79/ct/ohbci.xml
      /layers/heroku_deb-packages/packages/usr/lib/x86_64-linux-gnu/gwenhywfar/plugins/79/ct/ohbci.so
      /layers/heroku_deb-packages/packages/usr/lib/x86_64-linux-gnu/gwenhywfar/plugins/79/dbio/olddb.xml
      /layers/heroku_deb-packages/packages/usr/lib/x86_64-linux-gnu/gwenhywfar/plugins/79/dbio/olddb.so.0.0.1
      /layers/heroku_deb-packages/packages/usr/lib/x86_64-linux-gnu/gwenhywfar/plugins/79/dbio/csv.xml
      /layers/heroku_deb-packages/packages/usr/lib/x86_64-linux-gnu/gwenhywfar/plugins/79/dbio/xmldb.xml
      /layers/heroku_deb-packages/packages/usr/lib/x86_64-linux-gnu/gwenhywfar/plugins/79/dbio/xmldb.so.0.0.1
      /layers/heroku_deb-packages/packages/usr/lib/x86_64-linux-gnu/gwenhywfar/plugins/79/dbio/csv.so.0.0.1

  - Done (< 0.1s)
- Done (finished in 1m 43s)
```

Fixes #50 