### PR TITLE
Provide package name suggestions for `PackageNotFound` errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,6 +289,7 @@ dependencies = [
  "bon",
  "bullet_stream",
  "debversion",
+ "edit-distance",
  "futures 0.3.31",
  "indexmap",
  "indoc",
@@ -787,6 +788,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "edit-distance"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3f497e87b038c09a155dfd169faa5ec940d0644635555ef6bd464ac20e97397"
 
 [[package]]
 name = "either"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ async-compression = { version = "0.4", default-features = false, features = ["to
 bon = "2"
 bullet_stream = "0.3"
 debversion = "0.4"
+edit-distance = "2"
 futures = { version = "0.3", default-features = false, features = ["io-compat"] }
 indexmap = "2"
 libcnb = { version = "=0.25.0", features = ["trace"] }


### PR DESCRIPTION
When the user provides a mistyped package, we can use the package index to provide a list of suggested package names based on a Levenshtein distance. This list is limited to matches between 1 and 3 (inclusive) edit distances with a maximum of 5 results given.

Fixes #54