### PR TITLE
added code to set GIT_EXEC_PATH and the tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,7 @@ dependencies = [
  "ar",
  "async-compression",
  "bon",
+ "buildpacks-deb-packages",
  "bullet_stream",
  "debversion",
  "edit-distance",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ libcnb-test = "=0.26.0"
 regex = "1"
 strip-ansi-escapes = "0.2"
 tempfile = "3"
+buildpacks-deb-packages = { path = "." }
 
 [lints.rust]
 unreachable_pub = "warn"

--- a/README.md
+++ b/README.md
@@ -199,8 +199,9 @@ For each package added after [determining the packages to install](#step-2-deter
 | `INCLUDE_PATH`       | `/<layer_dir>/usr/include/<arch>` <br> `/<layer_dir>/usr/include`                                                | header files     |
 | `CPATH`              | Same as `INCLUDE_PATH`                                                                                           | header files     |
 | `CPPPATH`            | Same as `INCLUDE_PATH`                                                                                           | header files     |
-| `PKG_CONFIG_PATH`    | `/<layer_dir>/usr/lib/<arch>/pkgconfig` <br> `/<layer_dir>/usr/lib/pkgconfig`                                    | pc files         |
 
+| `PKG_CONFIG_PATH`    | `/<layer_dir>/usr/lib/<arch>/pkgconfig` <br> `/<layer_dir>/usr/lib/pkgconfig`                                    | pc files         |
+| `GIT_EXEC_PATH`    | `/<layer_dir>/app/.apt/usr/lib/git-core`                                    | git files         |
 ## Contributing
 
 Issues and pull requests are welcome. See our [contributing guidelines](./CONTRIBUTING.md) if you would like to help.

--- a/project.toml
+++ b/project.toml
@@ -1,0 +1,8 @@
+[_]
+schema-version = "0.2"
+
+[com.heroku.buildpacks.deb-packages]
+install = [
+  "git",
+  "systemd-cron"
+]

--- a/src/debian/multiarch_name.rs
+++ b/src/debian/multiarch_name.rs
@@ -1,6 +1,8 @@
 use std::fmt::{Display, Formatter};
 
 use crate::debian::ArchitectureName;
+use std::str::FromStr;
+// use std::fmt::{Display, Formatter};
 
 #[derive(Debug, PartialEq, Clone)]
 #[allow(non_camel_case_types)]
@@ -28,9 +30,32 @@ impl Display for MultiarchName {
     }
 }
 
+impl FromStr for MultiarchName {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "x86_64-linux-gnu" => Ok(MultiarchName::X86_64_LINUX_GNU),
+            "aarch64-linux-gnu" => Ok(MultiarchName::AARCH_64_LINUX_GNU),
+            _ => Err(()),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_multiarch_name_from_str() {
+        // Test valid strings
+        assert_eq!(MultiarchName::from_str("x86_64-linux-gnu").unwrap(), MultiarchName::X86_64_LINUX_GNU);
+        assert_eq!(MultiarchName::from_str("aarch64-linux-gnu").unwrap(), MultiarchName::AARCH_64_LINUX_GNU);
+
+        // Test invalid string
+        assert!(MultiarchName::from_str("invalid-arch").is_err());
+    }
 
     #[test]
     fn converting_architecture_name_to_multiarch_name() {

--- a/tests/fixtures/unit_tests/project.toml
+++ b/tests/fixtures/unit_tests/project.toml
@@ -1,0 +1,2 @@
+git = true
+ghostscript = true


### PR DESCRIPTION
This is in response to [Issue 137](https://github.com/heroku/heroku-buildpack-apt/issues/137) in the [heroku-buildpack-apt](https://github.com/heroku/heroku-buildpack-apt) repo.  

If `git` is in the `project.toml` file - make sure GIT_EXEC_PATH is correctly defined after successful installation or if it is already installed.

Added unit tests