### PR TITLE
Update detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,9 +45,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release.
 
 [unreleased]: https://github.com/heroku/buildpacks-deb-packages/compare/v0.0.3...HEAD
-
 [0.0.3]: https://github.com/heroku/buildpacks-deb-packages/compare/v0.0.2...v0.0.3
-
 [0.0.2]: https://github.com/heroku/buildpacks-deb-packages/compare/v0.0.1...v0.0.2
-
 [0.0.1]: https://github.com/heroku/buildpacks-deb-packages/releases/tag/v0.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Detect now passes if an `Aptfile` exists and will print a migration message during the build phase.
+
+### Changed
+
+- Detect now passes if `project.toml` is present and contains namespaced configuration.
+
 ## [0.0.3] - 2024-12-05
 
 ### Changed
@@ -37,6 +45,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release.
 
 [unreleased]: https://github.com/heroku/buildpacks-deb-packages/compare/v0.0.3...HEAD
+
 [0.0.3]: https://github.com/heroku/buildpacks-deb-packages/compare/v0.0.2...v0.0.3
+
 [0.0.2]: https://github.com/heroku/buildpacks-deb-packages/compare/v0.0.1...v0.0.2
+
 [0.0.1]: https://github.com/heroku/buildpacks-deb-packages/releases/tag/v0.0.1

--- a/README.md
+++ b/README.md
@@ -131,7 +131,10 @@ The following environment variables can be passed to the buildpack:
 
 This buildpack will pass detection if:
 
-- A `project.toml` file is found at the root of the application source directory
+- A `project.toml` file is found at the root of the application source directory containing configuration under the
+  `[com.heroku.buildpacks.deb-packages]` namespace.
+- An `Aptfile` is found. This will not be used by this buildpack but details for how to migrate away from
+  `Aptfile` configuration will be provided in the build phase if this file is present.
 
 ### Build
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -929,7 +929,7 @@ mod tests {
             indoc! {"
                 - Debug Info:
                   - test I/O error
-    
+
                 ! Unable to complete buildpack detection
                 !
                 ! An unexpected I/O error occurred while checking `/path/to/project.toml` to \
@@ -945,7 +945,7 @@ mod tests {
                 Context
                 -------
                 When detect is executed on this buildpack, we check to see if an Aptfile
-                exists since that's where configuration for the non-CNB variant of this 
+                exists since that's where configuration for the non-CNB variant of this
                 buildpack would be found so we can display a migration message to the user.
                 I/O operations can fail for a number of reasons which we can't anticipate and
                 the best we can do here is report the error message.
@@ -957,7 +957,7 @@ mod tests {
             indoc! {"
                 - Debug Info:
                   - test I/O error
-    
+
                 ! Unable to complete buildpack detection
                 !
                 ! An unexpected I/O error occurred while checking `/path/to/Aptfile` to \
@@ -1149,30 +1149,32 @@ mod tests {
 
     #[test]
     fn config_parse_config_error_for_missing_namespaced_config() {
-        test_error_output("
-            Context
-            -------
-            We read the buildpack configuration from project.toml which must be a valid TOML file.
-            If the file is valid but the there is no configuration supplied, we report this to the 
-            user and request they check the buildpack documentation for proper usage.
-        ",
-        ConfigError::ParseConfig(
-            "/path/to/project.toml".into(),
-            ParseConfigError::MissingNamespacedConfig
-        ), 
-        indoc! {"
-            ! Error parsing `/path/to/project.toml` with invalid key
-            !
-            ! The Heroku .deb Packages buildpack reads the configuration from `/path/to/project.toml` \
-            to complete the build but no configuration for the key `[com.heroku.buildpacks.deb-packages]` \
-            is present. The value of this key must be a TOML table.
-            !
-            ! Suggestions:
-            ! - See the buildpack documentation for the proper usage for this configuration at https://github.com/heroku/buildpacks-deb-packages#configuration
-            ! - See the TOML documentation for more details on the TOML table type at https://toml.io/en/v1.0.0
-            !
-            ! Use the debug information above to troubleshoot and retry your build.
-        "});
+        test_error_output(
+            "
+                Context
+                -------
+                We read the buildpack configuration from project.toml which must be a valid TOML file.
+                If the file is valid but the there is no configuration supplied, we report this to the
+                user and request they check the buildpack documentation for proper usage.
+            ",
+            ConfigError::ParseConfig(
+                "/path/to/project.toml".into(),
+                ParseConfigError::MissingNamespacedConfig,
+            ),
+            indoc! {"
+                ! Error parsing `/path/to/project.toml` with invalid key
+                !
+                ! The Heroku .deb Packages buildpack reads the configuration from `/path/to/project.toml` \
+                to complete the build but no configuration for the key `[com.heroku.buildpacks.deb-packages]` \
+                is present. The value of this key must be a TOML table.
+                !
+                ! Suggestions:
+                ! - See the buildpack documentation for the proper usage for this configuration at https://github.com/heroku/buildpacks-deb-packages#configuration
+                ! - See the TOML documentation for more details on the TOML table type at https://toml.io/en/v1.0.0
+                !
+                ! Use the debug information above to troubleshoot and retry your build.
+        "},
+        );
     }
 
     #[test]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1150,30 +1150,29 @@ mod tests {
     #[test]
     fn config_parse_config_error_for_missing_namespaced_config() {
         test_error_output("
-                Context
-                -------
-                We read the buildpack configuration from project.toml which must be a valid TOML file.
-                If the file is valid but the there is no configuration supplied, we report this to the 
-                user and request they check the buildpack documentation for proper usage.
-            ",
-            ConfigError::ParseConfig(
-              "/path/to/project.toml".into(),
-              ParseConfigError::MissingNamespacedConfig
-            ),
-indoc! {"
-                ! Error parsing `/path/to/project.toml` with invalid key
-                !
-                ! The Heroku .deb Packages buildpack reads the configuration from `/path/to/project.toml` \
-                to complete the build but no configuration for the key `[com.heroku.buildpacks.deb-packages]` \
-                is present. The value of this key must be a TOML table.
-                !
-                ! Suggestions:
-                ! - See the buildpack documentation for the proper usage for this configuration at https://github.com/heroku/buildpacks-deb-packages#configuration
-                ! - See the TOML documentation for more details on the TOML table type at https://toml.io/en/v1.0.0
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
-            "},
-        );
+            Context
+            -------
+            We read the buildpack configuration from project.toml which must be a valid TOML file.
+            If the file is valid but the there is no configuration supplied, we report this to the 
+            user and request they check the buildpack documentation for proper usage.
+        ",
+        ConfigError::ParseConfig(
+            "/path/to/project.toml".into(),
+            ParseConfigError::MissingNamespacedConfig
+        ), 
+        indoc! {"
+            ! Error parsing `/path/to/project.toml` with invalid key
+            !
+            ! The Heroku .deb Packages buildpack reads the configuration from `/path/to/project.toml` \
+            to complete the build but no configuration for the key `[com.heroku.buildpacks.deb-packages]` \
+            is present. The value of this key must be a TOML table.
+            !
+            ! Suggestions:
+            ! - See the buildpack documentation for the proper usage for this configuration at https://github.com/heroku/buildpacks-deb-packages#configuration
+            ! - See the TOML documentation for more details on the TOML table type at https://toml.io/en/v1.0.0
+            !
+            ! Use the debug information above to troubleshoot and retry your build.
+        "});
     }
 
     #[test]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -162,7 +162,7 @@ fn on_config_error(error: ConfigError) -> ErrorMessage {
 
                 ParseConfigError::MissingNamespacedConfig => {
                     create_error()
-                        .error_type(UserFacing(SuggestRetryBuild::Yes, SuggestSubmitIssue::No))
+                        .error_type(UserFacing(SuggestRetryBuild::No, SuggestSubmitIssue::No))
                         .header(format!("Error parsing {config_file} with invalid key"))
                         .body(formatdoc! { "
                             The {BUILDPACK_NAME} reads the configuration from {config_file} to complete \
@@ -757,7 +757,7 @@ fn on_detect_error(error: DetectError) -> ErrorMessage {
         DetectError::CheckExistsAptfile(file, e) | DetectError::CheckExistsProjectToml(file, e) => {
             let file = file_value(file);
             create_error()
-                .error_type(UserFacing(SuggestRetryBuild::No, SuggestSubmitIssue::No))
+                .error_type(UserFacing(SuggestRetryBuild::Yes, SuggestSubmitIssue::No))
                 .header("Unable to complete buildpack detection")
                 .body(formatdoc! { "
                     An unexpected I/O error occurred while checking {file} to determine if the \
@@ -934,6 +934,8 @@ mod tests {
                 !
                 ! An unexpected I/O error occurred while checking `/path/to/project.toml` to \
                 determine if the Heroku .deb Packages buildpack is compatible for this application.
+                !
+                ! Use the debug information above to troubleshoot and retry your build.
             "},
         );
     }
@@ -962,6 +964,8 @@ mod tests {
                 !
                 ! An unexpected I/O error occurred while checking `/path/to/Aptfile` to \
                 determine if the Heroku .deb Packages buildpack is compatible for this application.
+                !
+                ! Use the debug information above to troubleshoot and retry your build.
             "},
         );
     }
@@ -1171,8 +1175,6 @@ mod tests {
                 ! Suggestions:
                 ! - See the buildpack documentation for the proper usage for this configuration at https://github.com/heroku/buildpacks-deb-packages#configuration
                 ! - See the TOML documentation for more details on the TOML table type at https://toml.io/en/v1.0.0
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
         "},
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,11 +78,11 @@ impl Buildpack for DebianPackagesBuildpack {
             buildpack_version = context.buildpack_descriptor.buildpack.version
         ));
 
-        if let Some(_) = get_aptfile(&context.app_dir)? {
+        if get_aptfile(&context.app_dir)?.is_some() {
             log = log.important(migrate_from_aptfile_help_message());
             // If we passed detect from the Aptfile but there is no project.toml then
             // print the warning and exit early.
-            if let None = get_project_toml(&context.app_dir)? {
+            if get_project_toml(&context.app_dir)?.is_none() {
                 return BuildResultBuilder::new().build();
             }
         }


### PR DESCRIPTION
This is a small change tweak the buildpack detection here so that:
- detect doesn't simply pass if `project.toml` exists, the namespaced configuration also needs to be present
- detect will also pass if an `Aptfile` exists but only to emit a warning during the build phase about how to migrate to the `project.toml` configuration