### PR TITLE
Fix capitalisation of `project.toml` in log output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed capitalisation of `project.toml` in the detection failure log output. ([#97](https://github.com/heroku/buildpacks-deb-packages/pull/97))
+
 ## [0.1.1] - 2025-03-03
 
 ### Changed

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ impl Buildpack for DebianPackagesBuildpack {
             if BuildpackConfig::is_present(project_toml)? {
                 DetectResultBuilder::pass().build()
             } else {
-                log.important("Project.toml found, but no [com.heroku.buildpacks.deb-packages] configuration present.").done();
+                log.important("project.toml found, but no [com.heroku.buildpacks.deb-packages] configuration present.").done();
                 DetectResultBuilder::fail().build()
             }
         } else if get_aptfile(&context.app_dir)?.is_some() {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -46,7 +46,7 @@ fn test_failed_detection_when_project_file_has_no_config() {
             config.expected_pack_result(PackResult::Failure);
         },
         |ctx| {
-            assert_contains!(ctx.pack_stdout, "Project.toml found, but no [com.heroku.buildpacks.deb-packages] configuration present.");
+            assert_contains!(ctx.pack_stdout, "project.toml found, but no [com.heroku.buildpacks.deb-packages] configuration present.");
         },
     );
 }


### PR DESCRIPTION
Per:
https://github.com/heroku/buildpacks-deb-packages/pull/93/files#r1971363423