### PR TITLE
Support for custom Debian repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support custom Debian repositories through configuration. ([#116](https://github.com/heroku/buildpacks-deb-packages/pull/116))
+
 ### Changed
 
-- Minimum supported Rust version incremented to 1.86 to support syntax introduced in [115](https://github.com/heroku/buildpacks-deb-packages/pull/115). ([#117](https://github.com/heroku/buildpacks-deb-packages/pull/117))
+- Minimum supported Rust version incremented to 1.86 to support syntax introduced in [#115](https://github.com/heroku/buildpacks-deb-packages/pull/115). ([#117](https://github.com/heroku/buildpacks-deb-packages/pull/117))
 
 ## [0.1.3] - 2025-04-01
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ install = [
     # inline-table version of a dependency to install
     { name = "package-name", skip_dependencies = true, force = true }
 ]
+
+# one or more custom sources can be configured with the following:
+[[com.heroku.buildpacks.deb-packages.sources]]
+uri = "<url_of_debian_repository> (e.g.; http://archive.ubuntu.com/ubuntu)"
+suites = ["<suite> (e.g.; jammy)"]
+components = ["<component> (e.g.; main)"]
+arch = ["<architecture> (e.g.; amd64 or arm64)"]
+signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+<ASCII-armored GPG key>
+-----END PGP PUBLIC KEY BLOCK-----
+"""
 ```
 
 #### Schema
@@ -96,6 +107,30 @@ install = [
             - `force` *__([boolean][toml-boolean], optional, default = false)__*
 
               If set to `true`, the package will be installed even if it's already installed on the system.
+
+    - `sources` *__([array_of_tables][toml-array-of-tables], optional)__*
+
+        - `uri` *__([string][toml-string], required)__*
+
+          The URI must specify the base of the Debian repository.
+
+        - `suites` *__([array][toml-array] of [string][toml-string] values, required)__*
+
+          One or more distribution suites from the Debian repository.
+
+        - `components` *__([array][toml-array] of [string][toml-string] values, required)__*
+
+          One or more components which specify different sections of distribution versions present in a suite.
+
+        - `arch` *__([array][toml-array] of [string][toml-string] values, required)__*
+
+          One or more supported architecture names. The supported architecture names are:
+            - amd64
+            - arm64
+
+        - `signed_by` *__([string][toml-string], required)__*
+
+          The GPG key required by the Debian repository in ASCII-armored format.
 
 > [!TIP]
 > Users of the [heroku-community/apt][classic-apt-buildpack] can migrate their Aptfile to the above configuration by
@@ -262,3 +297,4 @@ Issues and pull requests are welcome. See our [contributing guidelines](./CONTRI
 
 [toml-table]: https://toml.io/en/v1.0.0#table
 
+[toml-array-of-tables]: https://toml.io/en/v1.0.0#array-of-tables

--- a/src/config/buildpack_config.rs
+++ b/src/config/buildpack_config.rs
@@ -159,7 +159,7 @@ suites = ["main"]
 components = ["multiverse"]
 arch = ["amd64", "arm64"]
 signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
-    
+
 NxRt3Z+7w5HMIN2laKp+ItxloPWGBdcHU4o2ZnWgsVT8Y/a+RED75DDbAQ6lS3fV
 sSlmQLExcf75qOPy34XNv3gWP4tbfIXXt8olflF8hwHggmKZzEImnzEozPabDsN7
 nkhHZEWhGcPRcuHbFOqcirV1sfsKK1gOsTbxS00iD3OivOFCQqujF196cal/utTd
@@ -194,7 +194,7 @@ iGa6i2oLaGzGaQZDpdqyQZiYpQEYw9xN+8g=
                 ]),
                 sources: Vec::from([CustomSource {
                     uri: "http://archive.ubuntu.com/ubuntu".into(),
-                    suites: vec!["noble/mongodb-org/8.0".into()],
+                    suites: vec!["main".into()],
                     components: vec!["multiverse".into()],
                     arch: vec![AMD_64, ARM_64],
                     signed_by: indoc! { "

--- a/src/config/buildpack_config.rs
+++ b/src/config/buildpack_config.rs
@@ -1,3 +1,4 @@
+use crate::config::custom_source::{CustomSource, ParseCustomSourceError};
 use crate::config::{ParseRequestedPackageError, RequestedPackage};
 use crate::DebianPackagesBuildpackError;
 use indexmap::IndexSet;
@@ -11,6 +12,7 @@ pub(crate) const NAMESPACED_CONFIG: &str = "com.heroku.buildpacks.deb-packages";
 #[derive(Debug, Default, Eq, PartialEq)]
 pub(crate) struct BuildpackConfig {
     pub(crate) install: IndexSet<RequestedPackage>,
+    pub(crate) sources: Vec<CustomSource>,
 }
 
 impl BuildpackConfig {
@@ -49,6 +51,7 @@ impl TryFrom<&dyn TableLike> for BuildpackConfig {
 
     fn try_from(config_item: &dyn TableLike) -> Result<Self, Self::Error> {
         let mut install = IndexSet::new();
+        let mut sources = Vec::new();
 
         if let Some(install_values) = config_item.get("install").and_then(|item| item.as_array()) {
             for install_value in install_values {
@@ -59,7 +62,19 @@ impl TryFrom<&dyn TableLike> for BuildpackConfig {
             }
         }
 
-        Ok(BuildpackConfig { install })
+        if let Some(source_values) = config_item
+            .get("sources")
+            .and_then(|item| item.as_array_of_tables())
+        {
+            for source_value in source_values {
+                sources.push(
+                    CustomSource::try_from(source_value)
+                        .map_err(|e| Self::Error::ParseCustomSource(Box::new(e)))?,
+                );
+            }
+        }
+
+        Ok(BuildpackConfig { install, sources })
     }
 }
 
@@ -74,6 +89,7 @@ pub(crate) enum ParseConfigError {
     InvalidToml(toml_edit::TomlError),
     MissingNamespacedConfig,
     ParseRequestedPackage(Box<ParseRequestedPackageError>),
+    ParseCustomSource(Box<ParseCustomSourceError>),
     WrongConfigType,
 }
 
@@ -117,7 +133,9 @@ fn get_buildpack_namespaced_config(doc: &DocumentMut) -> Result<&dyn TableLike, 
 
 #[cfg(test)]
 mod test {
+    use crate::debian::ArchitectureName::{AMD_64, ARM_64};
     use crate::debian::PackageName;
+    use indoc::indoc;
 
     use super::*;
 
@@ -133,6 +151,42 @@ install = [
     { name = "package2" },
     { name = "package3", skip_dependencies = true, force = true },
 ]
+
+[[com.heroku.buildpacks.deb-packages.sources]]
+uri = "http://archive.ubuntu.com/ubuntu"
+suites = ["noble/mongodb-org/8.0"]
+components = ["multiverse"]
+arch = ["amd64", "arm64"]
+signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mQINBGWgEhwBEADJpjwR+5n6na3tqZ6ueHsW/U8lvcvMFZ1DYNo+/JhrNjHkZ7HR
+Wbc2IzWej1zqTtctSKZvrCkPGZxiDsKB5xta/NVtnpjSuV02Gp0F6hf0gnvark04
+HnEFaV2w15Tyr8Z4KHRDbdja6h/24t4tR0KkRzxh5U7FwLL8BpK2drbTog9FBMy+
+lqYDfOLHx6JDeOMC7eSNe/jJsAiuVcP/y+vQbLuMYAaMPSvJoidRIQ88oFLoUlVZ
+NxRt3Z+7w5HMIN2laKp+ItxloPWGBdcHU4o2ZnWgsVT8Y/a+RED75DDbAQ6lS3fV
+sSlmQLExcf75qOPy34XNv3gWP4tbfIXXt8olflF8hwHggmKZzEImnzEozPabDsN7
+nkhHZEWhGcPRcuHbFOqcirV1sfsKK1gOsTbxS00iD3OivOFCQqujF196cal/utTd
+WvyJvY2o35eE0WFcDdstU7UiP39usE+jk4jbQS5WbMYk9yyZCCbd74T7eYAfSEXg
+GqrE1O6pjMmwbEjHwHDkbn/2WGvOSgWKHJVSh8V1K5ijlAd/9SCbsY0Yh5K3G16k
+gnzHZ7OuQItfvMlPLQA7P2cPj/bGkO2ayyZU4+9rCsXlHw4Cee+u1APFSO2rj1TE
+vX80grtqXNmj6nV21nIiXASvBKRO3kU4t8yV9i8EEREKYx/gLIl5i3PYGwARAQAB
+tDdNb25nb0RCIDguMCBSZWxlYXNlIFNpZ25pbmcgS2V5IDxwYWNrYWdpbmdAbW9u
+Z29kYi5jb20+iQJOBBMBCgA4FiEESwdSwbyiOMC07hTcQd4Fik59ygUFAmWgEhwC
+GwMFCwkIBwIGFQoJCAsCBBYCAwECHgECF4AACgkQQd4Fik59ygWy4w//e+IQ5eFT
+rlowx196DaInUTiv+aMkkN5hAtJDMicV9+ZDChEfqqQH1WJuUUKfX00AeEDocQnI
+LgESy0+rp2FoRPG5bXaJXTv6xQkqIMQQMNMkG4Nx3AxggRVkzd2arOr9FBwcnmf0
+7xu9EsMJndmzTsDO+ohWnNb0ILSdPVKDafpfg4ycBWDZT7ynD6TT0JpG8WWJi8F+
+9GR4k4CpBujk49POZbjeVDOuP/o/tosmEO9jo03C/u1qNuVVXy6vvTB6WjO79QTX
+OlSTLHAiu9N/VknG1B7lW15X1yl3jl3vZ33N68ncXUW2gAJi7Nh6H6RSm288IC4i
+hSmSBFabffQtwOTVE0CaKge2nU4Oc3Tp2h8moEgi81vYT/CioMt6wmHTzY0grcfF
+WLwtDMFJ0VQYRrUIOMmYBFyRp2jdRYYkA+vlL+6DNAAjCeuvwCs3PqUhgFvHNxVv
+bumKiRMIOoNUwpLEKsEq8jBs+U+gUfa+CmBn67G9mjDRu4cXXrtItooxnbfM/m0i
+hVnssTC1arrx273zFepLosPvgrT0TS7tnyXbzuq5mo0zD1fSj4kuSS9V/SSy9fWF
+LAtHiNQJkjzGFxu0/9dyQyX6C523uvfdcOzpObTyjBeGKqmEEf0lF5OYLDlkk2Sm
+iGa6i2oLaGzGaQZDpdqyQZiYpQEYw9xN+8g=
+=J31U
+-----END PGP PUBLIC KEY BLOCK-----
+"""
         "#
         .trim();
         let config = BuildpackConfig::from_str(toml).unwrap();
@@ -155,7 +209,45 @@ install = [
                         skip_dependencies: true,
                         force: true,
                     }
-                ])
+                ]),
+                sources: Vec::from([CustomSource {
+                    uri: "http://archive.ubuntu.com/ubuntu".into(),
+                    suites: vec!["noble/mongodb-org/8.0".into()],
+                    components: vec!["multiverse".into()],
+                    arch: vec![AMD_64, ARM_64],
+                    signed_by: indoc! { "
+                        -----BEGIN PGP PUBLIC KEY BLOCK-----
+
+                        mQINBGWgEhwBEADJpjwR+5n6na3tqZ6ueHsW/U8lvcvMFZ1DYNo+/JhrNjHkZ7HR
+                        Wbc2IzWej1zqTtctSKZvrCkPGZxiDsKB5xta/NVtnpjSuV02Gp0F6hf0gnvark04
+                        HnEFaV2w15Tyr8Z4KHRDbdja6h/24t4tR0KkRzxh5U7FwLL8BpK2drbTog9FBMy+
+                        lqYDfOLHx6JDeOMC7eSNe/jJsAiuVcP/y+vQbLuMYAaMPSvJoidRIQ88oFLoUlVZ
+                        NxRt3Z+7w5HMIN2laKp+ItxloPWGBdcHU4o2ZnWgsVT8Y/a+RED75DDbAQ6lS3fV
+                        sSlmQLExcf75qOPy34XNv3gWP4tbfIXXt8olflF8hwHggmKZzEImnzEozPabDsN7
+                        nkhHZEWhGcPRcuHbFOqcirV1sfsKK1gOsTbxS00iD3OivOFCQqujF196cal/utTd
+                        WvyJvY2o35eE0WFcDdstU7UiP39usE+jk4jbQS5WbMYk9yyZCCbd74T7eYAfSEXg
+                        GqrE1O6pjMmwbEjHwHDkbn/2WGvOSgWKHJVSh8V1K5ijlAd/9SCbsY0Yh5K3G16k
+                        gnzHZ7OuQItfvMlPLQA7P2cPj/bGkO2ayyZU4+9rCsXlHw4Cee+u1APFSO2rj1TE
+                        vX80grtqXNmj6nV21nIiXASvBKRO3kU4t8yV9i8EEREKYx/gLIl5i3PYGwARAQAB
+                        tDdNb25nb0RCIDguMCBSZWxlYXNlIFNpZ25pbmcgS2V5IDxwYWNrYWdpbmdAbW9u
+                        Z29kYi5jb20+iQJOBBMBCgA4FiEESwdSwbyiOMC07hTcQd4Fik59ygUFAmWgEhwC
+                        GwMFCwkIBwIGFQoJCAsCBBYCAwECHgECF4AACgkQQd4Fik59ygWy4w//e+IQ5eFT
+                        rlowx196DaInUTiv+aMkkN5hAtJDMicV9+ZDChEfqqQH1WJuUUKfX00AeEDocQnI
+                        LgESy0+rp2FoRPG5bXaJXTv6xQkqIMQQMNMkG4Nx3AxggRVkzd2arOr9FBwcnmf0
+                        7xu9EsMJndmzTsDO+ohWnNb0ILSdPVKDafpfg4ycBWDZT7ynD6TT0JpG8WWJi8F+
+                        9GR4k4CpBujk49POZbjeVDOuP/o/tosmEO9jo03C/u1qNuVVXy6vvTB6WjO79QTX
+                        OlSTLHAiu9N/VknG1B7lW15X1yl3jl3vZ33N68ncXUW2gAJi7Nh6H6RSm288IC4i
+                        hSmSBFabffQtwOTVE0CaKge2nU4Oc3Tp2h8moEgi81vYT/CioMt6wmHTzY0grcfF
+                        WLwtDMFJ0VQYRrUIOMmYBFyRp2jdRYYkA+vlL+6DNAAjCeuvwCs3PqUhgFvHNxVv
+                        bumKiRMIOoNUwpLEKsEq8jBs+U+gUfa+CmBn67G9mjDRu4cXXrtItooxnbfM/m0i
+                        hVnssTC1arrx273zFepLosPvgrT0TS7tnyXbzuq5mo0zD1fSj4kuSS9V/SSy9fWF
+                        LAtHiNQJkjzGFxu0/9dyQyX6C523uvfdcOzpObTyjBeGKqmEEf0lF5OYLDlkk2Sm
+                        iGa6i2oLaGzGaQZDpdqyQZiYpQEYw9xN+8g=
+                        =J31U
+                        -----END PGP PUBLIC KEY BLOCK-----\n"
+                    }
+                    .into()
+                }])
             }
         );
     }

--- a/src/config/buildpack_config.rs
+++ b/src/config/buildpack_config.rs
@@ -140,6 +140,7 @@ mod test {
     use super::*;
 
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn test_deserialize() {
         let toml = r#"
 [_]
@@ -154,33 +155,14 @@ install = [
 
 [[com.heroku.buildpacks.deb-packages.sources]]
 uri = "http://archive.ubuntu.com/ubuntu"
-suites = ["noble/mongodb-org/8.0"]
+suites = ["main"]
 components = ["multiverse"]
 arch = ["amd64", "arm64"]
 signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
-
-mQINBGWgEhwBEADJpjwR+5n6na3tqZ6ueHsW/U8lvcvMFZ1DYNo+/JhrNjHkZ7HR
-Wbc2IzWej1zqTtctSKZvrCkPGZxiDsKB5xta/NVtnpjSuV02Gp0F6hf0gnvark04
-HnEFaV2w15Tyr8Z4KHRDbdja6h/24t4tR0KkRzxh5U7FwLL8BpK2drbTog9FBMy+
-lqYDfOLHx6JDeOMC7eSNe/jJsAiuVcP/y+vQbLuMYAaMPSvJoidRIQ88oFLoUlVZ
+    
 NxRt3Z+7w5HMIN2laKp+ItxloPWGBdcHU4o2ZnWgsVT8Y/a+RED75DDbAQ6lS3fV
 sSlmQLExcf75qOPy34XNv3gWP4tbfIXXt8olflF8hwHggmKZzEImnzEozPabDsN7
 nkhHZEWhGcPRcuHbFOqcirV1sfsKK1gOsTbxS00iD3OivOFCQqujF196cal/utTd
-WvyJvY2o35eE0WFcDdstU7UiP39usE+jk4jbQS5WbMYk9yyZCCbd74T7eYAfSEXg
-GqrE1O6pjMmwbEjHwHDkbn/2WGvOSgWKHJVSh8V1K5ijlAd/9SCbsY0Yh5K3G16k
-gnzHZ7OuQItfvMlPLQA7P2cPj/bGkO2ayyZU4+9rCsXlHw4Cee+u1APFSO2rj1TE
-vX80grtqXNmj6nV21nIiXASvBKRO3kU4t8yV9i8EEREKYx/gLIl5i3PYGwARAQAB
-tDdNb25nb0RCIDguMCBSZWxlYXNlIFNpZ25pbmcgS2V5IDxwYWNrYWdpbmdAbW9u
-Z29kYi5jb20+iQJOBBMBCgA4FiEESwdSwbyiOMC07hTcQd4Fik59ygUFAmWgEhwC
-GwMFCwkIBwIGFQoJCAsCBBYCAwECHgECF4AACgkQQd4Fik59ygWy4w//e+IQ5eFT
-rlowx196DaInUTiv+aMkkN5hAtJDMicV9+ZDChEfqqQH1WJuUUKfX00AeEDocQnI
-LgESy0+rp2FoRPG5bXaJXTv6xQkqIMQQMNMkG4Nx3AxggRVkzd2arOr9FBwcnmf0
-7xu9EsMJndmzTsDO+ohWnNb0ILSdPVKDafpfg4ycBWDZT7ynD6TT0JpG8WWJi8F+
-9GR4k4CpBujk49POZbjeVDOuP/o/tosmEO9jo03C/u1qNuVVXy6vvTB6WjO79QTX
-OlSTLHAiu9N/VknG1B7lW15X1yl3jl3vZ33N68ncXUW2gAJi7Nh6H6RSm288IC4i
-hSmSBFabffQtwOTVE0CaKge2nU4Oc3Tp2h8moEgi81vYT/CioMt6wmHTzY0grcfF
-WLwtDMFJ0VQYRrUIOMmYBFyRp2jdRYYkA+vlL+6DNAAjCeuvwCs3PqUhgFvHNxVv
-bumKiRMIOoNUwpLEKsEq8jBs+U+gUfa+CmBn67G9mjDRu4cXXrtItooxnbfM/m0i
 hVnssTC1arrx273zFepLosPvgrT0TS7tnyXbzuq5mo0zD1fSj4kuSS9V/SSy9fWF
 LAtHiNQJkjzGFxu0/9dyQyX6C523uvfdcOzpObTyjBeGKqmEEf0lF5OYLDlkk2Sm
 iGa6i2oLaGzGaQZDpdqyQZiYpQEYw9xN+8g=
@@ -217,29 +199,10 @@ iGa6i2oLaGzGaQZDpdqyQZiYpQEYw9xN+8g=
                     arch: vec![AMD_64, ARM_64],
                     signed_by: indoc! { "
                         -----BEGIN PGP PUBLIC KEY BLOCK-----
-
-                        mQINBGWgEhwBEADJpjwR+5n6na3tqZ6ueHsW/U8lvcvMFZ1DYNo+/JhrNjHkZ7HR
-                        Wbc2IzWej1zqTtctSKZvrCkPGZxiDsKB5xta/NVtnpjSuV02Gp0F6hf0gnvark04
-                        HnEFaV2w15Tyr8Z4KHRDbdja6h/24t4tR0KkRzxh5U7FwLL8BpK2drbTog9FBMy+
-                        lqYDfOLHx6JDeOMC7eSNe/jJsAiuVcP/y+vQbLuMYAaMPSvJoidRIQ88oFLoUlVZ
+                       
                         NxRt3Z+7w5HMIN2laKp+ItxloPWGBdcHU4o2ZnWgsVT8Y/a+RED75DDbAQ6lS3fV
                         sSlmQLExcf75qOPy34XNv3gWP4tbfIXXt8olflF8hwHggmKZzEImnzEozPabDsN7
                         nkhHZEWhGcPRcuHbFOqcirV1sfsKK1gOsTbxS00iD3OivOFCQqujF196cal/utTd
-                        WvyJvY2o35eE0WFcDdstU7UiP39usE+jk4jbQS5WbMYk9yyZCCbd74T7eYAfSEXg
-                        GqrE1O6pjMmwbEjHwHDkbn/2WGvOSgWKHJVSh8V1K5ijlAd/9SCbsY0Yh5K3G16k
-                        gnzHZ7OuQItfvMlPLQA7P2cPj/bGkO2ayyZU4+9rCsXlHw4Cee+u1APFSO2rj1TE
-                        vX80grtqXNmj6nV21nIiXASvBKRO3kU4t8yV9i8EEREKYx/gLIl5i3PYGwARAQAB
-                        tDdNb25nb0RCIDguMCBSZWxlYXNlIFNpZ25pbmcgS2V5IDxwYWNrYWdpbmdAbW9u
-                        Z29kYi5jb20+iQJOBBMBCgA4FiEESwdSwbyiOMC07hTcQd4Fik59ygUFAmWgEhwC
-                        GwMFCwkIBwIGFQoJCAsCBBYCAwECHgECF4AACgkQQd4Fik59ygWy4w//e+IQ5eFT
-                        rlowx196DaInUTiv+aMkkN5hAtJDMicV9+ZDChEfqqQH1WJuUUKfX00AeEDocQnI
-                        LgESy0+rp2FoRPG5bXaJXTv6xQkqIMQQMNMkG4Nx3AxggRVkzd2arOr9FBwcnmf0
-                        7xu9EsMJndmzTsDO+ohWnNb0ILSdPVKDafpfg4ycBWDZT7ynD6TT0JpG8WWJi8F+
-                        9GR4k4CpBujk49POZbjeVDOuP/o/tosmEO9jo03C/u1qNuVVXy6vvTB6WjO79QTX
-                        OlSTLHAiu9N/VknG1B7lW15X1yl3jl3vZ33N68ncXUW2gAJi7Nh6H6RSm288IC4i
-                        hSmSBFabffQtwOTVE0CaKge2nU4Oc3Tp2h8moEgi81vYT/CioMt6wmHTzY0grcfF
-                        WLwtDMFJ0VQYRrUIOMmYBFyRp2jdRYYkA+vlL+6DNAAjCeuvwCs3PqUhgFvHNxVv
-                        bumKiRMIOoNUwpLEKsEq8jBs+U+gUfa+CmBn67G9mjDRu4cXXrtItooxnbfM/m0i
                         hVnssTC1arrx273zFepLosPvgrT0TS7tnyXbzuq5mo0zD1fSj4kuSS9V/SSy9fWF
                         LAtHiNQJkjzGFxu0/9dyQyX6C523uvfdcOzpObTyjBeGKqmEEf0lF5OYLDlkk2Sm
                         iGa6i2oLaGzGaQZDpdqyQZiYpQEYw9xN+8g=

--- a/src/config/custom_source.rs
+++ b/src/config/custom_source.rs
@@ -1,0 +1,76 @@
+use crate::debian::{ArchitectureName, RepositoryUri, Source};
+use toml_edit::Table;
+
+// Very similar in structure to a `Source` **except** it allows for multiple architectures
+// to be specified as configuration.
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct CustomSource {
+    pub(crate) arch: Vec<ArchitectureName>,
+    pub(crate) components: Vec<String>,
+    pub(crate) suites: Vec<String>,
+    pub(crate) uri: RepositoryUri,
+    pub(crate) signed_by: String,
+}
+
+impl CustomSource {
+    pub(crate) fn to_sources(&self) -> Vec<Source> {
+        self.arch
+            .iter()
+            .map(|arch| Source {
+                uri: self.uri.clone(),
+                suites: self.suites.clone(),
+                components: self.components.clone(),
+                signed_by: self.signed_by.clone(),
+                arch: arch.clone(),
+            })
+            .collect()
+    }
+}
+
+impl TryFrom<&Table> for CustomSource {
+    type Error = ParseCustomSourceError;
+
+    fn try_from(table: &Table) -> Result<Self, Self::Error> {
+        // todo: this needs more robust error handling
+
+        let uri = table.get("uri").and_then(|v| v.as_str()).unwrap().into();
+
+        let mut suites: Vec<String> = vec![];
+        if let Some(array) = table.get("suites").and_then(|v| v.as_array()) {
+            for suite in array {
+                suites.push(suite.as_str().unwrap().into());
+            }
+        }
+
+        let mut components: Vec<String> = vec![];
+        if let Some(array) = table.get("components").and_then(|v| v.as_array()) {
+            for component in array {
+                components.push(component.as_str().unwrap().into());
+            }
+        }
+
+        let mut arch: Vec<ArchitectureName> = vec![];
+        if let Some(array) = table.get("arch").and_then(|v| v.as_array()) {
+            for arch_value in array {
+                arch.push(arch_value.as_str().unwrap().parse().unwrap());
+            }
+        }
+
+        let gpg_key = table
+            .get("signed_by")
+            .and_then(|v| v.as_str())
+            .unwrap()
+            .into();
+
+        Ok(CustomSource {
+            uri,
+            suites,
+            components,
+            arch,
+            signed_by: gpg_key,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum ParseCustomSourceError {}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2,4 +2,5 @@ pub(crate) use buildpack_config::*;
 pub(crate) use requested_package::*;
 
 mod buildpack_config;
+mod custom_source;
 mod requested_package;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2,5 +2,5 @@ pub(crate) use buildpack_config::*;
 pub(crate) use requested_package::*;
 
 mod buildpack_config;
-mod custom_source;
+pub(crate) mod custom_source;
 mod requested_package;

--- a/src/create_package_index.rs
+++ b/src/create_package_index.rs
@@ -49,8 +49,8 @@ pub(crate) async fn create_package_index(
 ) -> BuildpackResult<PackageIndex> {
     print::header("Creating package index");
 
+    print::bullet("Package sources");
     for source in source_list {
-        print::bullet("Package sources");
         for suite in &source.suites {
             print::sub_bullet(format!(
                 "{repository_uri} {suite} [{components}]",

--- a/src/debian/architecture_name.rs
+++ b/src/debian/architecture_name.rs
@@ -1,3 +1,4 @@
+use indoc::formatdoc;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
@@ -32,13 +33,19 @@ impl Display for ArchitectureName {
 }
 
 #[derive(Debug)]
-// Due to how this error rolls into the broader `Distro::try_from(Target)` implementation, the
-// architecture name stored in this struct isn't used directly which triggers a `dead_code`
-// warning. I could eliminate this by not capturing the architecture name that failed to parse
-// but that doesn't seem right. I'd rather keep this information attached to this struct even
-// if it's not used at this point in time.
-#[allow(dead_code)]
-pub(crate) struct UnsupportedArchitectureNameError(String);
+pub(crate) struct UnsupportedArchitectureNameError(pub(crate) String);
+
+impl Display for UnsupportedArchitectureNameError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let error = formatdoc! { "
+            Unsupported architecture name: \"{invalid_name}\"
+            Must be one of:
+            - \"amd64\"
+            - \"arm64\"
+        ", invalid_name = &self.0 };
+        write!(f, "{error}")
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/determine_packages_to_install.rs
+++ b/src/determine_packages_to_install.rs
@@ -18,7 +18,7 @@ pub(crate) fn determine_packages_to_install(
     requested_packages: IndexSet<RequestedPackage>,
 ) -> BuildpackResult<Vec<RepositoryPackage>> {
     print::header("Determining packages to install");
-    print::sub_bullet("Collecting system install information");
+    print::bullet("Collecting system install information");
     let system_packages_path = PathBuf::from("/var/lib/dpkg/status");
     let system_packages = read_to_string(&system_packages_path)
         .map_err(|e| {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -168,7 +168,9 @@ fn on_config_error(error: ConfigError) -> ErrorMessage {
                             {toml_spec_url}
                         " })
                         .call()
-                },
+                }
+
+                ParseConfigError::ParseCustomSource(error) => todo!("Add proper error messages: {error:?}")
             }
         }
     }
@@ -998,11 +1000,11 @@ mod tests {
                 is not a TOML table then the configuration is incorrect and we can provide details to the
                 user on how they can fix this.
             ",
-            ConfigError::ParseConfig(
-                "/path/to/project.toml".into(),
-                ParseConfigError::WrongConfigType,
-            ),
-            indoc! {"
+                          ConfigError::ParseConfig(
+                              "/path/to/project.toml".into(),
+                              ParseConfigError::WrongConfigType,
+                          ),
+                          indoc! {"
                 ! Error parsing `/path/to/project.toml` with invalid key
                 !
                 ! The Heroku .deb Packages buildpack reads the configuration from `/path/to/project.toml` \
@@ -1028,13 +1030,13 @@ mod tests {
                 We read the buildpack configuration from project.toml which must be a valid TOML file.
                 This error will be reported if the file is not valid TOML.
             ",
-            ConfigError::ParseConfig(
-                "/path/to/project.toml".into(),
-                ParseConfigError::InvalidToml(
-                    toml_edit::DocumentMut::from_str("[com.heroku").unwrap_err(),
-                ),
-            ),
-            indoc! {"
+                          ConfigError::ParseConfig(
+                              "/path/to/project.toml".into(),
+                              ParseConfigError::InvalidToml(
+                                  toml_edit::DocumentMut::from_str("[com.heroku").unwrap_err(),
+                              ),
+                          ),
+                          indoc! {"
                 - Debug Info:
                   - TOML parse error at line 1, column 12
                       |
@@ -1066,15 +1068,15 @@ mod tests {
                 contains a package name that would be invalid according to Debian package naming policies,
                 we report this package name to the user and ask them to verify it.
             ",
-            ConfigError::ParseConfig(
-                "/path/to/project.toml".into(),
-                ParseConfigError::ParseRequestedPackage(
-                    Box::from(ParseRequestedPackageError::InvalidPackageName(ParsePackageNameError {
-                        package_name: "invalid!package!name".to_string(),
-                    })),
-                ),
-            ),
-            indoc! {"
+                          ConfigError::ParseConfig(
+                              "/path/to/project.toml".into(),
+                              ParseConfigError::ParseRequestedPackage(
+                                  Box::from(ParseRequestedPackageError::InvalidPackageName(ParsePackageNameError {
+                                      package_name: "invalid!package!name".to_string(),
+                                  })),
+                              ),
+                          ),
+                          indoc! {"
                 ! Error parsing `/path/to/project.toml` with invalid package name
                 !
                 ! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` \
@@ -1105,15 +1107,15 @@ mod tests {
                 We report this to the user and request they check the buildpack documentation for proper
                 usage.
             ",
-            ConfigError::ParseConfig(
-                "/path/to/project.toml".into(),
-                ParseConfigError::ParseRequestedPackage(
-                    Box::from(ParseRequestedPackageError::UnexpectedTomlValue(
-                        toml_edit::value(37).into_value().unwrap(),
-                    )),
-                ),
-            ),
-            indoc! {"
+                          ConfigError::ParseConfig(
+                              "/path/to/project.toml".into(),
+                              ParseConfigError::ParseRequestedPackage(
+                                  Box::from(ParseRequestedPackageError::UnexpectedTomlValue(
+                                      toml_edit::value(37).into_value().unwrap(),
+                                  )),
+                              ),
+                          ),
+                          indoc! {"
                 - Debug Info:
                   - Invalid type `integer` with value `37`
 
@@ -1179,12 +1181,12 @@ mod tests {
                 be helpful for developers hacking on this buildpack. Tools like pack also validate
                 buildpacks against their target distribution metadata to prevent this exact scenario.
             ",
-            UnsupportedDistro(UnsupportedDistroError {
-                name: "Windows".to_string(),
-                version: "XP".to_string(),
-                architecture: "x86".to_string(),
-            }),
-            indoc! {"
+                          UnsupportedDistro(UnsupportedDistroError {
+                              name: "Windows".to_string(),
+                              version: "XP".to_string(),
+                              architecture: "x86".to_string(),
+                          }),
+                          indoc! {"
                 ! Unsupported distribution
                 !
                 ! The Heroku .deb Packages buildpack doesn't support the Windows XP (x86) distribution.
@@ -1216,8 +1218,8 @@ mod tests {
                 ones for a specific architecture. Our testing processes should always catch this but,
                 if not, we should direct users to file an issue.
             ",
-            CreatePackageIndexError::NoSources,
-            indoc! {"
+                          CreatePackageIndexError::NoSources,
+                          indoc! {"
                 ! No sources to update
                 !
                 ! The distribution has no sources to update packages from.
@@ -1763,7 +1765,7 @@ mod tests {
             CreatePackageIndexError::ChecksumFailed {
                 url: "http://ports.ubuntu.com/ubuntu-ports/dists/noble/main/binary-arm64/by-hash/SHA256/d41d8cd98f00b204e9800998ecf8427e".to_string(),
                 expected: "d41d8cd98f00b204e9800998ecf8427e".to_string(),
-                actual: "e62ff0123a74adfc6903d59a449cbdb0".to_string()
+                actual: "e62ff0123a74adfc6903d59a449cbdb0".to_string(),
             },
             indoc! {"
                 ! Package Index checksum verification failed

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,3 +1,4 @@
+use crate::config::custom_source::ParseCustomSourceError;
 use crate::config::{ConfigError, ParseConfigError, ParseRequestedPackageError, NAMESPACED_CONFIG};
 use crate::create_package_index::CreatePackageIndexError;
 use crate::debian::UnsupportedDistroError;
@@ -170,7 +171,74 @@ fn on_config_error(error: ConfigError) -> ErrorMessage {
                         .call()
                 }
 
-                ParseConfigError::ParseCustomSource(error) => todo!("Add proper error messages: {error:?}")
+                ParseConfigError::ParseCustomSource(error) => {
+                    let custom_source_array_of_tables_key = "[[com.heroku.buildpacks.deb-packages.sources]]";
+                    create_error()
+                        .error_type(UserFacing(SuggestRetryBuild::Yes, SuggestSubmitIssue::No))
+                        .header(format!("Error parsing {config_file} with invalid custom source"))
+                        .body(formatdoc! { r#"
+                            The {BUILDPACK_NAME} reads configuration from {config_file} to \
+                            complete the build but we found an invalid custom source in the \
+                            key {root_config_key}.
+
+                            Custom sources must be in the following format:
+
+                            {custom_source_array_of_tables_key}
+                            uri = "<url_of_debian_repository> (e.g.; http://archive.ubuntu.com/ubuntu)"
+                            suites = ["<suite> (e.g.; jammy)"]
+                            components = ["<component> (e.g.; main)"]
+                            arch = ["<architecture> (e.g.; amd64 or arm64)"]
+                            signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+                            <ASCII-armored GPG key>
+                            -----END PGP PUBLIC KEY BLOCK-----
+
+                            Suggestions:
+                            - See the buildpack documentation for the proper usage for this configuration at \
+                            {configuration_doc_url}
+                            - See the TOML documentation for more details on the TOML array of tables type \
+                            at {toml_spec_url}
+                            "# })
+                        .debug_info(match *error {
+                            ParseCustomSourceError::MissingUri(table) => formatdoc! { "
+                                Missing or invalid \"uri\" field for the following custom source:
+                                {custom_source_array_of_tables_key}
+                                {table}
+                            " },
+                            ParseCustomSourceError::MissingSignedBy(table) => formatdoc! { "
+                                Missing or invalid \"signed_by\" field for the following custom source:
+                                {custom_source_array_of_tables_key}
+                                {table}
+                            " },
+                            ParseCustomSourceError::MissingSuites(table) => formatdoc! { "
+                                Missing or invalid \"suites\" field. One or more String values must be present for the following custom source:
+                                {custom_source_array_of_tables_key}
+                                {table}
+                            " },
+                            ParseCustomSourceError::MissingComponents(table) => formatdoc! { "
+                                Missing or invalid \"components\" field. One or more String values must be present for the following custom source:
+                                {custom_source_array_of_tables_key}
+                                {table}
+                            " },
+                            ParseCustomSourceError::MissingArchitectureNames(table) => formatdoc! { "
+                                Missing or invalid \"arch\" field. One or more String values must be present for the following custom source:
+                                {custom_source_array_of_tables_key}
+                                {table}
+                            " },
+                            ParseCustomSourceError::UnexpectedTomlValue(table, value) => formatdoc! { "
+                                Unexpected toml value (\"{value}\") found for the following custom source:
+                                {custom_source_array_of_tables_key}
+                                {table}
+                            " },
+                            ParseCustomSourceError::InvalidArchitectureName(table, e) => formatdoc! { "
+                                Invalid architecture name found for the following custom source:
+                                {custom_source_array_of_tables_key}
+                                {table}
+                                ---
+                                {e}
+                            " },
+                        })
+                        .call()
+                }
             }
         }
     }
@@ -891,6 +959,7 @@ mod tests {
     use super::*;
     use crate::debian::{
         ParsePackageNameError, ParseRepositoryPackageError, RepositoryPackage, RepositoryUri,
+        UnsupportedArchitectureNameError,
     };
     use crate::DebianPackagesBuildpackError::UnsupportedDistro;
     use anyhow::anyhow;
@@ -899,6 +968,7 @@ mod tests {
     use libcnb_test::assert_contains_match;
     use std::collections::HashSet;
     use std::str::FromStr;
+    use toml_edit::Table;
 
     #[test]
     fn test_detect_check_exists_project_toml_error() {
@@ -1165,6 +1235,471 @@ mod tests {
                 ! - See the buildpack documentation for the proper usage for this configuration at https://github.com/heroku/buildpacks-deb-packages#configuration
                 ! - See the TOML documentation for more details on the TOML table type at https://toml.io/en/v1.0.0
         "},
+        );
+    }
+
+    #[test]
+    fn config_parse_config_error_for_custom_source_with_missing_uri() {
+        let mut table = create_custom_source_table();
+        table.remove("uri");
+        test_error_output(
+            "
+                Context
+                -------
+                We read the buildpack configuration from project.toml which must be a valid TOML file.
+                If the file is valid but the value supplied using the configuration for this buildpack
+                contains a custom source that is missing the 'uri' field, it is invalid.
+                We report this to the user and request they check the buildpack documentation for proper
+                usage.
+            ",
+            ConfigError::ParseConfig(
+                "/path/to/project.toml".into(),
+                ParseConfigError::ParseCustomSource(Box::from(ParseCustomSourceError::MissingUri(table))),
+            ),
+            &formatdoc! { r#"
+                - Debug Info:
+                  - Missing or invalid "uri" field for the following custom source:
+                    [[com.heroku.buildpacks.deb-packages.sources]]
+                    suites = ["main"]
+                    components = ["multiverse"]
+                    arch = ["amd64", "arm64"]
+                    signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+                    NxRt3Z+7w5HMIN2laKp+ItxloPWGBdcHU4o2ZnWgsVT8Y/a+RED75DDbAQ6lS3fV
+                    sSlmQLExcf75qOPy34XNv3gWP4tbfIXXt8olflF8hwHggmKZzEImnzEozPabDsN7
+                    nkhHZEWhGcPRcuHbFOqcirV1sfsKK1gOsTbxS00iD3OivOFCQqujF196cal/utTd
+                    hVnssTC1arrx273zFepLosPvgrT0TS7tnyXbzuq5mo0zD1fSj4kuSS9V/SSy9fWF
+                    LAtHiNQJkjzGFxu0/9dyQyX6C523uvfdcOzpObTyjBeGKqmEEf0lF5OYLDlkk2Sm
+                    iGa6i2oLaGzGaQZDpdqyQZiYpQEYw9xN+8g=
+                    =J31U
+                    -----END PGP PUBLIC KEY BLOCK-----
+                    """
+
+                ! Error parsing `/path/to/project.toml` with invalid custom source
+                !
+                ! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` to \
+                ! complete the build but we found an invalid custom source in the \
+                ! key `[com.heroku.buildpacks.deb-packages]`.
+                !
+                ! Custom sources must be in the following format:
+                !
+                ! [[com.heroku.buildpacks.deb-packages.sources]]
+                ! uri = "<url_of_debian_repository> (e.g.; http://archive.ubuntu.com/ubuntu)"
+                ! suites = ["<suite> (e.g.; jammy)"]
+                ! components = ["<component> (e.g.; main)"]
+                ! arch = ["<architecture> (e.g.; amd64 or arm64)"]
+                ! signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+                ! <ASCII-armored GPG key>
+                ! -----END PGP PUBLIC KEY BLOCK-----
+                !
+                ! Suggestions:
+                ! - See the buildpack documentation for the proper usage for this configuration at \
+                ! https://github.com/heroku/buildpacks-deb-packages#configuration
+                ! - See the TOML documentation for more details on the TOML array of tables type \
+                ! at https://toml.io/en/v1.0.0
+                !
+                ! Use the debug information above to troubleshoot and retry your build.
+        "#},
+        );
+    }
+
+    #[test]
+    fn config_parse_config_error_for_custom_source_with_missing_signed_by() {
+        let mut table = create_custom_source_table();
+        table.remove("signed_by");
+        test_error_output(
+            "
+                Context
+                -------
+                We read the buildpack configuration from project.toml which must be a valid TOML file.
+                If the file is valid but the value supplied using the configuration for this buildpack
+                contains a custom source that is missing the 'signed_by' field, it is invalid.
+                We report this to the user and request they check the buildpack documentation for proper
+                usage.
+            ",
+            ConfigError::ParseConfig(
+                "/path/to/project.toml".into(),
+                ParseConfigError::ParseCustomSource(Box::from(ParseCustomSourceError::MissingSignedBy(table))),
+            ),
+            &formatdoc! { r#"
+                - Debug Info:
+                  - Missing or invalid "signed_by" field for the following custom source:
+                    [[com.heroku.buildpacks.deb-packages.sources]]
+                    uri = "http://archive.ubuntu.com/ubuntu"
+                    suites = ["main"]
+                    components = ["multiverse"]
+                    arch = ["amd64", "arm64"]
+
+                ! Error parsing `/path/to/project.toml` with invalid custom source
+                !
+                ! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` to \
+                ! complete the build but we found an invalid custom source in the \
+                ! key `[com.heroku.buildpacks.deb-packages]`.
+                !
+                ! Custom sources must be in the following format:
+                !
+                ! [[com.heroku.buildpacks.deb-packages.sources]]
+                ! uri = "<url_of_debian_repository> (e.g.; http://archive.ubuntu.com/ubuntu)"
+                ! suites = ["<suite> (e.g.; jammy)"]
+                ! components = ["<component> (e.g.; main)"]
+                ! arch = ["<architecture> (e.g.; amd64 or arm64)"]
+                ! signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+                ! <ASCII-armored GPG key>
+                ! -----END PGP PUBLIC KEY BLOCK-----
+                !
+                ! Suggestions:
+                ! - See the buildpack documentation for the proper usage for this configuration at \
+                ! https://github.com/heroku/buildpacks-deb-packages#configuration
+                ! - See the TOML documentation for more details on the TOML array of tables type \
+                ! at https://toml.io/en/v1.0.0
+                !
+                ! Use the debug information above to troubleshoot and retry your build.
+        "#},
+        );
+    }
+
+    #[test]
+    fn config_parse_config_error_for_custom_source_with_missing_suites() {
+        let mut table = create_custom_source_table();
+        table.remove("suites");
+        test_error_output(
+            "
+                Context
+                -------
+                We read the buildpack configuration from project.toml which must be a valid TOML file.
+                If the file is valid but the value supplied using the configuration for this buildpack
+                contains a custom source that is missing the 'suites' field or the field contains
+                non-string values, it is invalid.
+                We report this to the user and request they check the buildpack documentation for proper
+                usage.
+            ",
+            ConfigError::ParseConfig(
+                "/path/to/project.toml".into(),
+                ParseConfigError::ParseCustomSource(Box::from(ParseCustomSourceError::MissingSuites(table))),
+            ),
+            &formatdoc! { r#"
+                - Debug Info:
+                  - Missing or invalid "suites" field. One or more String values must be present for the following custom source:
+                    [[com.heroku.buildpacks.deb-packages.sources]]
+                    uri = "http://archive.ubuntu.com/ubuntu"
+                    components = ["multiverse"]
+                    arch = ["amd64", "arm64"]
+                    signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+                    NxRt3Z+7w5HMIN2laKp+ItxloPWGBdcHU4o2ZnWgsVT8Y/a+RED75DDbAQ6lS3fV
+                    sSlmQLExcf75qOPy34XNv3gWP4tbfIXXt8olflF8hwHggmKZzEImnzEozPabDsN7
+                    nkhHZEWhGcPRcuHbFOqcirV1sfsKK1gOsTbxS00iD3OivOFCQqujF196cal/utTd
+                    hVnssTC1arrx273zFepLosPvgrT0TS7tnyXbzuq5mo0zD1fSj4kuSS9V/SSy9fWF
+                    LAtHiNQJkjzGFxu0/9dyQyX6C523uvfdcOzpObTyjBeGKqmEEf0lF5OYLDlkk2Sm
+                    iGa6i2oLaGzGaQZDpdqyQZiYpQEYw9xN+8g=
+                    =J31U
+                    -----END PGP PUBLIC KEY BLOCK-----
+                    """
+
+                ! Error parsing `/path/to/project.toml` with invalid custom source
+                !
+                ! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` to \
+                ! complete the build but we found an invalid custom source in the \
+                ! key `[com.heroku.buildpacks.deb-packages]`.
+                !
+                ! Custom sources must be in the following format:
+                !
+                ! [[com.heroku.buildpacks.deb-packages.sources]]
+                ! uri = "<url_of_debian_repository> (e.g.; http://archive.ubuntu.com/ubuntu)"
+                ! suites = ["<suite> (e.g.; jammy)"]
+                ! components = ["<component> (e.g.; main)"]
+                ! arch = ["<architecture> (e.g.; amd64 or arm64)"]
+                ! signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+                ! <ASCII-armored GPG key>
+                ! -----END PGP PUBLIC KEY BLOCK-----
+                !
+                ! Suggestions:
+                ! - See the buildpack documentation for the proper usage for this configuration at \
+                ! https://github.com/heroku/buildpacks-deb-packages#configuration
+                ! - See the TOML documentation for more details on the TOML array of tables type \
+                ! at https://toml.io/en/v1.0.0
+                !
+                ! Use the debug information above to troubleshoot and retry your build.
+        "#},
+        );
+    }
+
+    #[test]
+    fn config_parse_config_error_for_custom_source_with_missing_components() {
+        let mut table = create_custom_source_table();
+        table.remove("components");
+        test_error_output(
+            "
+                Context
+                -------
+                We read the buildpack configuration from project.toml which must be a valid TOML file.
+                If the file is valid but the value supplied using the configuration for this buildpack
+                contains a custom source that is missing the 'components' field or the field contains
+                non-string values, it is invalid.
+                We report this to the user and request they check the buildpack documentation for proper
+                usage.
+            ",
+            ConfigError::ParseConfig(
+                "/path/to/project.toml".into(),
+                ParseConfigError::ParseCustomSource(Box::from(ParseCustomSourceError::MissingComponents(table))),
+            ),
+            &formatdoc! { r#"
+                - Debug Info:
+                  - Missing or invalid "components" field. One or more String values must be present for the following custom source:
+                    [[com.heroku.buildpacks.deb-packages.sources]]
+                    uri = "http://archive.ubuntu.com/ubuntu"
+                    suites = ["main"]
+                    arch = ["amd64", "arm64"]
+                    signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+                    NxRt3Z+7w5HMIN2laKp+ItxloPWGBdcHU4o2ZnWgsVT8Y/a+RED75DDbAQ6lS3fV
+                    sSlmQLExcf75qOPy34XNv3gWP4tbfIXXt8olflF8hwHggmKZzEImnzEozPabDsN7
+                    nkhHZEWhGcPRcuHbFOqcirV1sfsKK1gOsTbxS00iD3OivOFCQqujF196cal/utTd
+                    hVnssTC1arrx273zFepLosPvgrT0TS7tnyXbzuq5mo0zD1fSj4kuSS9V/SSy9fWF
+                    LAtHiNQJkjzGFxu0/9dyQyX6C523uvfdcOzpObTyjBeGKqmEEf0lF5OYLDlkk2Sm
+                    iGa6i2oLaGzGaQZDpdqyQZiYpQEYw9xN+8g=
+                    =J31U
+                    -----END PGP PUBLIC KEY BLOCK-----
+                    """
+
+                ! Error parsing `/path/to/project.toml` with invalid custom source
+                !
+                ! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` to \
+                ! complete the build but we found an invalid custom source in the \
+                ! key `[com.heroku.buildpacks.deb-packages]`.
+                !
+                ! Custom sources must be in the following format:
+                !
+                ! [[com.heroku.buildpacks.deb-packages.sources]]
+                ! uri = "<url_of_debian_repository> (e.g.; http://archive.ubuntu.com/ubuntu)"
+                ! suites = ["<suite> (e.g.; jammy)"]
+                ! components = ["<component> (e.g.; main)"]
+                ! arch = ["<architecture> (e.g.; amd64 or arm64)"]
+                ! signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+                ! <ASCII-armored GPG key>
+                ! -----END PGP PUBLIC KEY BLOCK-----
+                !
+                ! Suggestions:
+                ! - See the buildpack documentation for the proper usage for this configuration at \
+                ! https://github.com/heroku/buildpacks-deb-packages#configuration
+                ! - See the TOML documentation for more details on the TOML array of tables type \
+                ! at https://toml.io/en/v1.0.0
+                !
+                ! Use the debug information above to troubleshoot and retry your build.
+        "#},
+        );
+    }
+
+    #[test]
+    fn config_parse_config_error_for_custom_source_with_invalid_components() {
+        let mut table = create_custom_source_table();
+        let mut components = toml_edit::Array::new();
+        components.push(123);
+        table.insert(
+            "components",
+            toml_edit::Item::Value(toml_edit::Value::from(components)),
+        );
+        test_error_output(
+            "
+                Context
+                -------
+                We read the buildpack configuration from project.toml which must be a valid TOML file.
+                If the file is valid but the value supplied using the configuration for this buildpack
+                contains a custom source that is missing the 'components' field or the field contains
+                non-string values, it is invalid.
+                We report this to the user and request they check the buildpack documentation for proper
+                usage.
+            ",
+            ConfigError::ParseConfig(
+                "/path/to/project.toml".into(),
+                ParseConfigError::ParseCustomSource(Box::from(ParseCustomSourceError::UnexpectedTomlValue(table, toml_edit::value(123).into_value().unwrap()))),
+            ),
+            &formatdoc! { r#"
+                - Debug Info:
+                  - Unexpected toml value ("123") found for the following custom source:
+                    [[com.heroku.buildpacks.deb-packages.sources]]
+                    uri = "http://archive.ubuntu.com/ubuntu"
+                    suites = ["main"]
+                    components = [123]
+                    arch = ["amd64", "arm64"]
+                    signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+                    NxRt3Z+7w5HMIN2laKp+ItxloPWGBdcHU4o2ZnWgsVT8Y/a+RED75DDbAQ6lS3fV
+                    sSlmQLExcf75qOPy34XNv3gWP4tbfIXXt8olflF8hwHggmKZzEImnzEozPabDsN7
+                    nkhHZEWhGcPRcuHbFOqcirV1sfsKK1gOsTbxS00iD3OivOFCQqujF196cal/utTd
+                    hVnssTC1arrx273zFepLosPvgrT0TS7tnyXbzuq5mo0zD1fSj4kuSS9V/SSy9fWF
+                    LAtHiNQJkjzGFxu0/9dyQyX6C523uvfdcOzpObTyjBeGKqmEEf0lF5OYLDlkk2Sm
+                    iGa6i2oLaGzGaQZDpdqyQZiYpQEYw9xN+8g=
+                    =J31U
+                    -----END PGP PUBLIC KEY BLOCK-----
+                    """
+
+                ! Error parsing `/path/to/project.toml` with invalid custom source
+                !
+                ! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` to \
+                ! complete the build but we found an invalid custom source in the \
+                ! key `[com.heroku.buildpacks.deb-packages]`.
+                !
+                ! Custom sources must be in the following format:
+                !
+                ! [[com.heroku.buildpacks.deb-packages.sources]]
+                ! uri = "<url_of_debian_repository> (e.g.; http://archive.ubuntu.com/ubuntu)"
+                ! suites = ["<suite> (e.g.; jammy)"]
+                ! components = ["<component> (e.g.; main)"]
+                ! arch = ["<architecture> (e.g.; amd64 or arm64)"]
+                ! signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+                ! <ASCII-armored GPG key>
+                ! -----END PGP PUBLIC KEY BLOCK-----
+                !
+                ! Suggestions:
+                ! - See the buildpack documentation for the proper usage for this configuration at \
+                ! https://github.com/heroku/buildpacks-deb-packages#configuration
+                ! - See the TOML documentation for more details on the TOML array of tables type \
+                ! at https://toml.io/en/v1.0.0
+                !
+                ! Use the debug information above to troubleshoot and retry your build.
+        "#},
+        );
+    }
+
+    #[test]
+    fn config_parse_config_error_for_custom_source_with_missing_architecture_names() {
+        let mut table = create_custom_source_table();
+        table.remove("arch");
+        test_error_output(
+            "
+                Context
+                -------
+                We read the buildpack configuration from project.toml which must be a valid TOML file.
+                If the file is valid but the value supplied using the configuration for this buildpack
+                contains a custom source that is missing the 'arch' field or the field contains
+                non-string values or unsupported architecture names, it is invalid.
+                We report this to the user and request they check the buildpack documentation for proper
+                usage.
+            ",
+            ConfigError::ParseConfig(
+                "/path/to/project.toml".into(),
+                ParseConfigError::ParseCustomSource(Box::from(ParseCustomSourceError::MissingArchitectureNames(table))),
+            ),
+            &formatdoc! { r#"
+                - Debug Info:
+                  - Missing or invalid "arch" field. One or more String values must be present for the following custom source:
+                    [[com.heroku.buildpacks.deb-packages.sources]]
+                    uri = "http://archive.ubuntu.com/ubuntu"
+                    suites = ["main"]
+                    components = ["multiverse"]
+                    signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+                    NxRt3Z+7w5HMIN2laKp+ItxloPWGBdcHU4o2ZnWgsVT8Y/a+RED75DDbAQ6lS3fV
+                    sSlmQLExcf75qOPy34XNv3gWP4tbfIXXt8olflF8hwHggmKZzEImnzEozPabDsN7
+                    nkhHZEWhGcPRcuHbFOqcirV1sfsKK1gOsTbxS00iD3OivOFCQqujF196cal/utTd
+                    hVnssTC1arrx273zFepLosPvgrT0TS7tnyXbzuq5mo0zD1fSj4kuSS9V/SSy9fWF
+                    LAtHiNQJkjzGFxu0/9dyQyX6C523uvfdcOzpObTyjBeGKqmEEf0lF5OYLDlkk2Sm
+                    iGa6i2oLaGzGaQZDpdqyQZiYpQEYw9xN+8g=
+                    =J31U
+                    -----END PGP PUBLIC KEY BLOCK-----
+                    """
+
+                ! Error parsing `/path/to/project.toml` with invalid custom source
+                !
+                ! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` to \
+                ! complete the build but we found an invalid custom source in the \
+                ! key `[com.heroku.buildpacks.deb-packages]`.
+                !
+                ! Custom sources must be in the following format:
+                !
+                ! [[com.heroku.buildpacks.deb-packages.sources]]
+                ! uri = "<url_of_debian_repository> (e.g.; http://archive.ubuntu.com/ubuntu)"
+                ! suites = ["<suite> (e.g.; jammy)"]
+                ! components = ["<component> (e.g.; main)"]
+                ! arch = ["<architecture> (e.g.; amd64 or arm64)"]
+                ! signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+                ! <ASCII-armored GPG key>
+                ! -----END PGP PUBLIC KEY BLOCK-----
+                !
+                ! Suggestions:
+                ! - See the buildpack documentation for the proper usage for this configuration at \
+                ! https://github.com/heroku/buildpacks-deb-packages#configuration
+                ! - See the TOML documentation for more details on the TOML array of tables type \
+                ! at https://toml.io/en/v1.0.0
+                !
+                ! Use the debug information above to troubleshoot and retry your build.
+        "#},
+        );
+    }
+
+    #[test]
+    fn config_parse_config_error_for_custom_source_with_invalid_architecture_name() {
+        let mut table = create_custom_source_table();
+        let mut arch = toml_edit::Array::new();
+        arch.push("i386");
+        table.insert("arch", toml_edit::Item::Value(toml_edit::Value::from(arch)));
+        test_error_output(
+            "
+                Context
+                -------
+                We read the buildpack configuration from project.toml which must be a valid TOML file.
+                If the file is valid but the value supplied using the configuration for this buildpack
+                contains a custom source that is missing the 'arch' field or the field contains
+                non-string values or unsupported architecture names, it is invalid.
+                We report this to the user and request they check the buildpack documentation for proper
+                usage.
+            ",
+            ConfigError::ParseConfig(
+                "/path/to/project.toml".into(),
+                ParseConfigError::ParseCustomSource(Box::from(ParseCustomSourceError::InvalidArchitectureName(table, UnsupportedArchitectureNameError("i386".into())))),
+            ),
+            &formatdoc! { r#"
+                - Debug Info:
+                  - Invalid architecture name found for the following custom source:
+                    [[com.heroku.buildpacks.deb-packages.sources]]
+                    uri = "http://archive.ubuntu.com/ubuntu"
+                    suites = ["main"]
+                    components = ["multiverse"]
+                    arch = ["i386"]
+                    signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+                    NxRt3Z+7w5HMIN2laKp+ItxloPWGBdcHU4o2ZnWgsVT8Y/a+RED75DDbAQ6lS3fV
+                    sSlmQLExcf75qOPy34XNv3gWP4tbfIXXt8olflF8hwHggmKZzEImnzEozPabDsN7
+                    nkhHZEWhGcPRcuHbFOqcirV1sfsKK1gOsTbxS00iD3OivOFCQqujF196cal/utTd
+                    hVnssTC1arrx273zFepLosPvgrT0TS7tnyXbzuq5mo0zD1fSj4kuSS9V/SSy9fWF
+                    LAtHiNQJkjzGFxu0/9dyQyX6C523uvfdcOzpObTyjBeGKqmEEf0lF5OYLDlkk2Sm
+                    iGa6i2oLaGzGaQZDpdqyQZiYpQEYw9xN+8g=
+                    =J31U
+                    -----END PGP PUBLIC KEY BLOCK-----
+                    """
+
+                    ---
+                    Unsupported architecture name: "i386"
+                    Must be one of:
+                    - "amd64"
+                    - "arm64"
+
+                ! Error parsing `/path/to/project.toml` with invalid custom source
+                !
+                ! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` to \
+                ! complete the build but we found an invalid custom source in the \
+                ! key `[com.heroku.buildpacks.deb-packages]`.
+                !
+                ! Custom sources must be in the following format:
+                !
+                ! [[com.heroku.buildpacks.deb-packages.sources]]
+                ! uri = "<url_of_debian_repository> (e.g.; http://archive.ubuntu.com/ubuntu)"
+                ! suites = ["<suite> (e.g.; jammy)"]
+                ! components = ["<component> (e.g.; main)"]
+                ! arch = ["<architecture> (e.g.; amd64 or arm64)"]
+                ! signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+                ! <ASCII-armored GPG key>
+                ! -----END PGP PUBLIC KEY BLOCK-----
+                !
+                ! Suggestions:
+                ! - See the buildpack documentation for the proper usage for this configuration at \
+                ! https://github.com/heroku/buildpacks-deb-packages#configuration
+                ! - See the TOML documentation for more details on the TOML array of tables type \
+                ! at https://toml.io/en/v1.0.0
+                !
+                ! Use the debug information above to troubleshoot and retry your build.
+        "#},
         );
     }
 
@@ -2538,6 +3073,29 @@ mod tests {
             .join("\n")
             .trim()
             .to_string()
+    }
+
+    fn create_custom_source_table() -> Table {
+        toml_edit::DocumentMut::from_str(indoc! { r#"
+            uri = "http://archive.ubuntu.com/ubuntu"
+            suites = ["main"]
+            components = ["multiverse"]
+            arch = ["amd64", "arm64"]
+            signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+            NxRt3Z+7w5HMIN2laKp+ItxloPWGBdcHU4o2ZnWgsVT8Y/a+RED75DDbAQ6lS3fV
+            sSlmQLExcf75qOPy34XNv3gWP4tbfIXXt8olflF8hwHggmKZzEImnzEozPabDsN7
+            nkhHZEWhGcPRcuHbFOqcirV1sfsKK1gOsTbxS00iD3OivOFCQqujF196cal/utTd
+            hVnssTC1arrx273zFepLosPvgrT0TS7tnyXbzuq5mo0zD1fSj4kuSS9V/SSy9fWF
+            LAtHiNQJkjzGFxu0/9dyQyX6C523uvfdcOzpObTyjBeGKqmEEf0lF5OYLDlkk2Sm
+            iGa6i2oLaGzGaQZDpdqyQZiYpQEYw9xN+8g=
+            =J31U
+            -----END PGP PUBLIC KEY BLOCK-----
+            """
+        "# })
+        .unwrap()
+        .as_table()
+        .clone()
     }
 
     fn create_io_error(text: &str) -> std::io::Error {

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,7 +126,17 @@ impl Buildpack for DebianPackagesBuildpack {
 
         let distro = Distro::try_from(&context.target)?;
 
-        let source_list = distro.get_source_list();
+        // official source list from distro
+        let mut source_list = distro.get_source_list();
+
+        // custom sources from configuration
+        for custom_source in config.sources {
+            for source in custom_source.to_sources() {
+                if source.arch == distro.architecture {
+                    source_list.push(source);
+                }
+            }
+        }
 
         info!(
             { DISTRO_NAME } = %distro.name,

--- a/tests/fixtures/custom_repository_noble/project.toml
+++ b/tests/fixtures/custom_repository_noble/project.toml
@@ -1,0 +1,45 @@
+[_]
+schema-version = "0.2"
+
+[com.heroku.buildpacks.deb-packages]
+install = [
+  # packages from custom repository
+  "mongodb-org-tools",
+  "mongodb-org-shell"
+]
+
+[[com.heroku.buildpacks.deb-packages.sources]]
+uri = "https://repo.mongodb.org/apt/ubuntu"
+suites = ["noble/mongodb-org/8.0"]
+components = ["multiverse"]
+arch = ["amd64", "arm64"]
+signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mQINBGWgEhwBEADJpjwR+5n6na3tqZ6ueHsW/U8lvcvMFZ1DYNo+/JhrNjHkZ7HR
+Wbc2IzWej1zqTtctSKZvrCkPGZxiDsKB5xta/NVtnpjSuV02Gp0F6hf0gnvark04
+HnEFaV2w15Tyr8Z4KHRDbdja6h/24t4tR0KkRzxh5U7FwLL8BpK2drbTog9FBMy+
+lqYDfOLHx6JDeOMC7eSNe/jJsAiuVcP/y+vQbLuMYAaMPSvJoidRIQ88oFLoUlVZ
+NxRt3Z+7w5HMIN2laKp+ItxloPWGBdcHU4o2ZnWgsVT8Y/a+RED75DDbAQ6lS3fV
+sSlmQLExcf75qOPy34XNv3gWP4tbfIXXt8olflF8hwHggmKZzEImnzEozPabDsN7
+nkhHZEWhGcPRcuHbFOqcirV1sfsKK1gOsTbxS00iD3OivOFCQqujF196cal/utTd
+WvyJvY2o35eE0WFcDdstU7UiP39usE+jk4jbQS5WbMYk9yyZCCbd74T7eYAfSEXg
+GqrE1O6pjMmwbEjHwHDkbn/2WGvOSgWKHJVSh8V1K5ijlAd/9SCbsY0Yh5K3G16k
+gnzHZ7OuQItfvMlPLQA7P2cPj/bGkO2ayyZU4+9rCsXlHw4Cee+u1APFSO2rj1TE
+vX80grtqXNmj6nV21nIiXASvBKRO3kU4t8yV9i8EEREKYx/gLIl5i3PYGwARAQAB
+tDdNb25nb0RCIDguMCBSZWxlYXNlIFNpZ25pbmcgS2V5IDxwYWNrYWdpbmdAbW9u
+Z29kYi5jb20+iQJOBBMBCgA4FiEESwdSwbyiOMC07hTcQd4Fik59ygUFAmWgEhwC
+GwMFCwkIBwIGFQoJCAsCBBYCAwECHgECF4AACgkQQd4Fik59ygWy4w//e+IQ5eFT
+rlowx196DaInUTiv+aMkkN5hAtJDMicV9+ZDChEfqqQH1WJuUUKfX00AeEDocQnI
+LgESy0+rp2FoRPG5bXaJXTv6xQkqIMQQMNMkG4Nx3AxggRVkzd2arOr9FBwcnmf0
+7xu9EsMJndmzTsDO+ohWnNb0ILSdPVKDafpfg4ycBWDZT7ynD6TT0JpG8WWJi8F+
+9GR4k4CpBujk49POZbjeVDOuP/o/tosmEO9jo03C/u1qNuVVXy6vvTB6WjO79QTX
+OlSTLHAiu9N/VknG1B7lW15X1yl3jl3vZ33N68ncXUW2gAJi7Nh6H6RSm288IC4i
+hSmSBFabffQtwOTVE0CaKge2nU4Oc3Tp2h8moEgi81vYT/CioMt6wmHTzY0grcfF
+WLwtDMFJ0VQYRrUIOMmYBFyRp2jdRYYkA+vlL+6DNAAjCeuvwCs3PqUhgFvHNxVv
+bumKiRMIOoNUwpLEKsEq8jBs+U+gUfa+CmBn67G9mjDRu4cXXrtItooxnbfM/m0i
+hVnssTC1arrx273zFepLosPvgrT0TS7tnyXbzuq5mo0zD1fSj4kuSS9V/SSy9fWF
+LAtHiNQJkjzGFxu0/9dyQyX6C523uvfdcOzpObTyjBeGKqmEEf0lF5OYLDlkk2Sm
+iGa6i2oLaGzGaQZDpdqyQZiYpQEYw9xN+8g=
+=J31U
+-----END PGP PUBLIC KEY BLOCK-----
+"""

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -566,7 +566,22 @@ fn vips_usage() {
     );
 }
 
-const DEFAULT_BUILDER: &str = "heroku/builder:22";
+#[test]
+#[ignore = "integration test"]
+fn custom_repository_for_noble_distro() {
+    if get_integration_test_builder().as_str() != "heroku/builder:24" {
+        return;
+    }
+    integration_test("fixtures/custom_repository_noble", |ctx| {
+        assert_contains!(ctx.pack_stderr, "https://repo.mongodb.org/apt/ubuntu noble/mongodb-org/8.0 [multiverse]");
+        assert_contains!(ctx.pack_stderr, "Downloaded release file https://repo.mongodb.org/apt/ubuntu/dists/noble/mongodb-org/8.0/InRelease");
+        assert_contains!(ctx.pack_stderr, "Downloaded package index https://repo.mongodb.org/apt/ubuntu/dists/noble/mongodb-org/8.0/multiverse/binary-amd64/Packages.gz");
+        assert_contains!(ctx.pack_stderr, "Adding `mongodb-org-tools");
+        assert_contains!(ctx.pack_stderr, "Adding `mongodb-org-shell");
+    });
+}
+
+const DEFAULT_BUILDER: &str = "heroku/builder:24";
 
 fn get_integration_test_builder() -> String {
     std::env::var("INTEGRATION_TEST_CNB_BUILDER").unwrap_or(DEFAULT_BUILDER.to_string())

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -575,7 +575,7 @@ fn custom_repository_for_noble_distro() {
     integration_test("fixtures/custom_repository_noble", |ctx| {
         assert_contains!(ctx.pack_stderr, "https://repo.mongodb.org/apt/ubuntu noble/mongodb-org/8.0 [multiverse]");
         assert_contains!(ctx.pack_stderr, "Downloaded release file https://repo.mongodb.org/apt/ubuntu/dists/noble/mongodb-org/8.0/InRelease");
-        assert_contains!(ctx.pack_stderr, "Downloaded package index https://repo.mongodb.org/apt/ubuntu/dists/noble/mongodb-org/8.0/multiverse/binary-amd64/Packages.gz");
+        assert_contains_match!(ctx.pack_stderr, r"Downloaded package index https://repo.mongodb.org/apt/ubuntu/dists/noble/mongodb-org/8.0/multiverse/binary-(amd|arm)64/Packages.gz");
         assert_contains!(ctx.pack_stderr, "Adding `mongodb-org-tools");
         assert_contains!(ctx.pack_stderr, "Adding `mongodb-org-shell");
     });


### PR DESCRIPTION
Adding a custom Debian repository can be done by adding configuration to `project.toml` using a similar structure to the Deb822-style Format for sources. The following fields must be provided as a TOML table under the key `[[com.heroku.buildpacks.deb-packages.sources]]`:
- `uri` - String
- `suites` - [String]
- `components` - [String]
- `arch` - [String]
- `signed_by` - String

For example, to add the [Debian repository for MongoDB](https://www.mongodb.com/docs/manual/tutorial/install-mongodb-on-ubuntu/), it would look like this:
```toml
[[com.heroku.buildpacks.deb-packages.sources]]
uri = "https://repo.mongodb.org/apt/ubuntu"
suites = ["noble/mongodb-org/8.0"]
components = ["multiverse"]
arch = ["amd64", "arm64"]
signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----

mQINBGWgEhwBEADJpjwR+5n6na3tqZ6ueHsW/U8lvcvMFZ1DYNo+/JhrNjHkZ7HR
Wbc2IzWej1zqTtctSKZvrCkPGZxiDsKB5xta/NVtnpjSuV02Gp0F6hf0gnvark04
HnEFaV2w15Tyr8Z4KHRDbdja6h/24t4tR0KkRzxh5U7FwLL8BpK2drbTog9FBMy+
lqYDfOLHx6JDeOMC7eSNe/jJsAiuVcP/y+vQbLuMYAaMPSvJoidRIQ88oFLoUlVZ
NxRt3Z+7w5HMIN2laKp+ItxloPWGBdcHU4o2ZnWgsVT8Y/a+RED75DDbAQ6lS3fV
sSlmQLExcf75qOPy34XNv3gWP4tbfIXXt8olflF8hwHggmKZzEImnzEozPabDsN7
nkhHZEWhGcPRcuHbFOqcirV1sfsKK1gOsTbxS00iD3OivOFCQqujF196cal/utTd
WvyJvY2o35eE0WFcDdstU7UiP39usE+jk4jbQS5WbMYk9yyZCCbd74T7eYAfSEXg
GqrE1O6pjMmwbEjHwHDkbn/2WGvOSgWKHJVSh8V1K5ijlAd/9SCbsY0Yh5K3G16k
gnzHZ7OuQItfvMlPLQA7P2cPj/bGkO2ayyZU4+9rCsXlHw4Cee+u1APFSO2rj1TE
vX80grtqXNmj6nV21nIiXASvBKRO3kU4t8yV9i8EEREKYx/gLIl5i3PYGwARAQAB
tDdNb25nb0RCIDguMCBSZWxlYXNlIFNpZ25pbmcgS2V5IDxwYWNrYWdpbmdAbW9u
Z29kYi5jb20+iQJOBBMBCgA4FiEESwdSwbyiOMC07hTcQd4Fik59ygUFAmWgEhwC
GwMFCwkIBwIGFQoJCAsCBBYCAwECHgECF4AACgkQQd4Fik59ygWy4w//e+IQ5eFT
rlowx196DaInUTiv+aMkkN5hAtJDMicV9+ZDChEfqqQH1WJuUUKfX00AeEDocQnI
LgESy0+rp2FoRPG5bXaJXTv6xQkqIMQQMNMkG4Nx3AxggRVkzd2arOr9FBwcnmf0
7xu9EsMJndmzTsDO+ohWnNb0ILSdPVKDafpfg4ycBWDZT7ynD6TT0JpG8WWJi8F+
9GR4k4CpBujk49POZbjeVDOuP/o/tosmEO9jo03C/u1qNuVVXy6vvTB6WjO79QTX
OlSTLHAiu9N/VknG1B7lW15X1yl3jl3vZ33N68ncXUW2gAJi7Nh6H6RSm288IC4i
hSmSBFabffQtwOTVE0CaKge2nU4Oc3Tp2h8moEgi81vYT/CioMt6wmHTzY0grcfF
WLwtDMFJ0VQYRrUIOMmYBFyRp2jdRYYkA+vlL+6DNAAjCeuvwCs3PqUhgFvHNxVv
bumKiRMIOoNUwpLEKsEq8jBs+U+gUfa+CmBn67G9mjDRu4cXXrtItooxnbfM/m0i
hVnssTC1arrx273zFepLosPvgrT0TS7tnyXbzuq5mo0zD1fSj4kuSS9V/SSy9fWF
LAtHiNQJkjzGFxu0/9dyQyX6C523uvfdcOzpObTyjBeGKqmEEf0lF5OYLDlkk2Sm
iGa6i2oLaGzGaQZDpdqyQZiYpQEYw9xN+8g=
=J31U
-----END PGP PUBLIC KEY BLOCK-----
"""
```

> [!NOTE]
> The GPG signing key is required in ASCII-format.

Fixes #110.