### PR TITLE
Update Rust minimum version to 1.86

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Minimum supported Rust version incremented to 1.86 to support syntax introduced in [115](https://github.com/heroku/buildpacks-deb-packages/pull/115). ([#NNNN](https://github.com/heroku/buildpacks-deb-packages/pull/NNNN))
+
 ## [0.1.3] - 2025-04-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Minimum supported Rust version incremented to 1.86 to support syntax introduced in [115](https://github.com/heroku/buildpacks-deb-packages/pull/115). ([#NNNN](https://github.com/heroku/buildpacks-deb-packages/pull/NNNN))
+- Minimum supported Rust version incremented to 1.86 to support syntax introduced in [115](https://github.com/heroku/buildpacks-deb-packages/pull/115). ([#117](https://github.com/heroku/buildpacks-deb-packages/pull/117))
 
 ## [0.1.3] - 2025-04-01
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "buildpacks-deb-packages"
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.86"
 
 [build-dependencies]
 toml_edit = "0.22"


### PR DESCRIPTION
More details in this PR to bullet_stream https://github.com/heroku-buildpacks/bullet_stream/pull/47. And this comment reporting the issue https://github.com/heroku/buildpacks-deb-packages/issues/110#issuecomment-2997899858.

The short version is: This buildpack uses a dependency that accidentally uses a feature stabilized in Rust 1.86, but it didn't correctly update the minimum required Rust version. If it had, when https://github.com/heroku/buildpacks-deb-packages/pull/115 was merged, it would have also triggered the change that's now being made (I'm guessing this field is not linted, but I've not verified). This change corrects the problem by correctly stating the minimum Rust version so all dependencies can compile correctly.

[GUS-W-18939940](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-18939940)