### PR TITLE
Spike for supporting buildplan configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,7 @@ dependencies = [
  "tokio",
  "tokio-tar",
  "tokio-util",
+ "toml 0.9.4",
  "toml_edit 0.23.2",
  "tracing",
  "walkdir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ tokio = { version = "1", default-features = false, features = ["rt-multi-thread"
 tokio-tar = "0.3"
 tokio-util = { version = "0.7", default-features = false, features = ["compat", "io"] }
 toml_edit = "0.23"
+toml = "0.9"
 tracing = "0.1"
 walkdir = "2"
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -241,6 +241,8 @@ fn on_config_error(error: ConfigError) -> ErrorMessage {
                 }
             }
         }
+
+        ConfigError::ParseBuildplanConfig(e) => todo!("{e:?}"),
     }
 }
 


### PR DESCRIPTION
> [!WARNING]
> This is just an experiment. Do not merge!

## Use Case

Let's say you're writing a CNB and, for the functionality your buildpack provides, you need to ensure one or more system packages are installed. Great! You can use `heroku/deb-packages` for that! One tiny problem though, the `heroku/deb-packages` CNB only supports configuration via `project.toml`. This means that your buildpack has to instruct users to manually add the required configuration for the packages it requires or it won't work. Wouldn't it be nice if your buildpack could instead just contribute the required configuration via the buildplan?

## Solution

This PR exposes the same configuration structure that available to end users in `project.toml` to buildpack authors in a buildplan. To leverage this configuration, a participating CNB needs to do the following in the `detect` phase:

- require the `heroku/deb-packages` buildplan and provide all necessary configuration under the `metadata` field.

### Example

###### `detect.sh`

```sh
#!/usr/bin/env bash
build_plan="$2"

cat <<EOF >"$build_plan"
[[requires]]
name = "heroku/deb-packages"

[requires.metadata]
# add custom packages
install = ["mongodb-org-tools", "mongodb-org-shell"]

# register a custom source
[[requires.metadata.sources]]
uri = "https://repo.mongodb.org/apt/ubuntu"
suites = ["noble/mongodb-org/8.0"]
components = ["multiverse"]
arch = ["amd64", "arm64"]
signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----

mQINBGWgEhwBEADJpjwR+5n6na3tqZ6ueHsW/U8lvcvMFZ1DYNo+/JhrNjHkZ7HR
Wbc2IzWej1zqTtctSKZvrCkPGZxiDsKB5xta/NVtnpjSuV02Gp0F6hf0gnvark04
HnEFaV2w15Tyr8Z4KHRDbdja6h/24t4tR0KkRzxh5U7FwLL8BpK2drbTog9FBMy+
lqYDfOLHx6JDeOMC7eSNe/jJsAiuVcP/y+vQbLuMYAaMPSvJoidRIQ88oFLoUlVZ
NxRt3Z+7w5HMIN2laKp+ItxloPWGBdcHU4o2ZnWgsVT8Y/a+RED75DDbAQ6lS3fV
sSlmQLExcf75qOPy34XNv3gWP4tbfIXXt8olflF8hwHggmKZzEImnzEozPabDsN7
nkhHZEWhGcPRcuHbFOqcirV1sfsKK1gOsTbxS00iD3OivOFCQqujF196cal/utTd
WvyJvY2o35eE0WFcDdstU7UiP39usE+jk4jbQS5WbMYk9yyZCCbd74T7eYAfSEXg
GqrE1O6pjMmwbEjHwHDkbn/2WGvOSgWKHJVSh8V1K5ijlAd/9SCbsY0Yh5K3G16k
gnzHZ7OuQItfvMlPLQA7P2cPj/bGkO2ayyZU4+9rCsXlHw4Cee+u1APFSO2rj1TE
vX80grtqXNmj6nV21nIiXASvBKRO3kU4t8yV9i8EEREKYx/gLIl5i3PYGwARAQAB
tDdNb25nb0RCIDguMCBSZWxlYXNlIFNpZ25pbmcgS2V5IDxwYWNrYWdpbmdAbW9u
Z29kYi5jb20+iQJOBBMBCgA4FiEESwdSwbyiOMC07hTcQd4Fik59ygUFAmWgEhwC
GwMFCwkIBwIGFQoJCAsCBBYCAwECHgECF4AACgkQQd4Fik59ygWy4w//e+IQ5eFT
rlowx196DaInUTiv+aMkkN5hAtJDMicV9+ZDChEfqqQH1WJuUUKfX00AeEDocQnI
LgESy0+rp2FoRPG5bXaJXTv6xQkqIMQQMNMkG4Nx3AxggRVkzd2arOr9FBwcnmf0
7xu9EsMJndmzTsDO+ohWnNb0ILSdPVKDafpfg4ycBWDZT7ynD6TT0JpG8WWJi8F+
9GR4k4CpBujk49POZbjeVDOuP/o/tosmEO9jo03C/u1qNuVVXy6vvTB6WjO79QTX
OlSTLHAiu9N/VknG1B7lW15X1yl3jl3vZ33N68ncXUW2gAJi7Nh6H6RSm288IC4i
hSmSBFabffQtwOTVE0CaKge2nU4Oc3Tp2h8moEgi81vYT/CioMt6wmHTzY0grcfF
WLwtDMFJ0VQYRrUIOMmYBFyRp2jdRYYkA+vlL+6DNAAjCeuvwCs3PqUhgFvHNxVv
bumKiRMIOoNUwpLEKsEq8jBs+U+gUfa+CmBn67G9mjDRu4cXXrtItooxnbfM/m0i
hVnssTC1arrx273zFepLosPvgrT0TS7tnyXbzuq5mo0zD1fSj4kuSS9V/SSy9fWF
LAtHiNQJkjzGFxu0/9dyQyX6C523uvfdcOzpObTyjBeGKqmEEf0lF5OYLDlkk2Sm
iGa6i2oLaGzGaQZDpdqyQZiYpQEYw9xN+8g=
=J31U
-----END PGP PUBLIC KEY BLOCK-----
"""
EOF