### PR TITLE
Convert error tests to insta snapshot testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,6 +314,7 @@ dependencies = [
  "hex",
  "indexmap",
  "indoc",
+ "insta",
  "libcnb",
  "libcnb-test",
  "rayon",
@@ -435,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -545,6 +546,17 @@ name = "compression-core"
 version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+
+[[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "const-hex"
@@ -966,6 +978,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,9 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
 
 [[package]]
 name = "ff"
@@ -1623,6 +1641,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.47.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+dependencies = [
+ "console",
+ "once_cell",
+ "regex",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1914,9 +1945,9 @@ dependencies = [
 
 [[package]]
 name = "liblzma-sys"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f2db66f3268487b5033077f266da6777d057949b8f93c8ad82e441df25e6186"
+checksum = "1a60851d15cd8c5346eca4ab8babff585be2ae4bc8097c067291d3ffe2add3b6"
 dependencies = [
  "cc",
  "libc",
@@ -2996,9 +3027,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -3188,6 +3219,12 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,6 +319,7 @@ dependencies = [
  "hex",
  "indexmap",
  "indoc",
+ "insta",
  "libcnb",
  "libcnb-test",
  "rayon",
@@ -374,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "camellia"
@@ -441,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -524,7 +525,7 @@ version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
- "bytes 1.12.0",
+ "bytes 1.12.1",
  "memchr",
 ]
 
@@ -547,6 +548,17 @@ name = "compression-core"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
+name = "console"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "const-hex"
@@ -638,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -648,18 +660,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-bigint"
@@ -990,6 +1002,12 @@ checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
 dependencies = [
  "log",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -1349,7 +1367,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
- "bytes 1.12.0",
+ "bytes 1.12.1",
  "itoa",
 ]
 
@@ -1359,7 +1377,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
- "bytes 1.12.0",
+ "bytes 1.12.1",
  "http",
 ]
 
@@ -1369,7 +1387,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
- "bytes 1.12.0",
+ "bytes 1.12.1",
  "futures-core",
  "http",
  "http-body",
@@ -1409,7 +1427,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
- "bytes 1.12.0",
+ "bytes 1.12.1",
  "futures-channel",
  "futures-core",
  "http",
@@ -1444,7 +1462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64",
- "bytes 1.12.0",
+ "bytes 1.12.1",
  "futures-channel",
  "futures-util",
  "http",
@@ -1604,9 +1622,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe112b004901c62c2faa11f4f75e9864e0cc5af8da71c9115d184a3aa888749f"
+checksum = "2adf14691c72bcfc1058740436a35bdd3ae9c07d1a941ef00b749e9ea16aefa7"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -1645,6 +1663,20 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array 0.14.7",
+]
+
+[[package]]
+name = "insta"
+version = "1.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
+dependencies = [
+ "console",
+ "once_cell",
+ "regex",
+ "similar",
+ "strip-ansi-escapes",
+ "tempfile",
 ]
 
 [[package]]
@@ -1728,11 +1760,11 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
@@ -2021,9 +2053,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memsec"
@@ -2110,9 +2142,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -2145,11 +2177,10 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -2416,7 +2447,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.52",
+ "zerocopy 0.8.54",
 ]
 
 [[package]]
@@ -2474,7 +2505,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
- "bytes 1.12.0",
+ "bytes 1.12.1",
  "prost-derive",
 ]
 
@@ -2642,9 +2673,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2654,9 +2685,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2676,7 +2707,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
- "bytes 1.12.0",
+ "bytes 1.12.1",
  "futures-core",
  "futures-util",
  "http",
@@ -2917,9 +2948,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "same-file"
@@ -2995,9 +3026,9 @@ dependencies = [
 
 [[package]]
 name = "sequoia-openpgp"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e421679c8175ef4674d913af7fdb8ad0078c8a2599db633ad0b4d02a06b2cb3c"
+checksum = "0fbc8f9818a6fad141d85993777ba298ee52c80a09bd23d45dda461a6b7c83cb"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -3240,6 +3271,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3324,6 +3361,15 @@ dependencies = [
  "parking_lot",
  "phf_shared",
  "precomputed-hash",
+]
+
+[[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
 ]
 
 [[package]]
@@ -3442,7 +3488,7 @@ version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
- "bytes 1.12.0",
+ "bytes 1.12.1",
  "libc",
  "mio",
  "pin-project-lite",
@@ -3503,7 +3549,7 @@ version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
- "bytes 1.12.0",
+ "bytes 1.12.1",
  "futures-core",
  "futures-io",
  "futures-sink",
@@ -3585,7 +3631,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags 2.13.0",
- "bytes 1.12.0",
+ "bytes 1.12.1",
  "futures-util",
  "http",
  "http-body",
@@ -3775,6 +3821,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "walkdir"
@@ -4172,11 +4227,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
- "zerocopy-derive 0.8.52",
+ "zerocopy-derive 0.8.54",
 ]
 
 [[package]]
@@ -4192,9 +4247,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ tracing = "0.1"
 walkdir = "2"
 
 [dev-dependencies]
+insta = { version = "1", features = ["filters"] }
 libcnb-test = "0.30"
 regex = "1"
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ tracing = "0.1"
 walkdir = "2"
 
 [dev-dependencies]
+insta = { version = "1", features = ["filters"] }
 libcnb-test = "=0.31.0"
 regex = "1"
 tempfile = "3"

--- a/src/__snapshots/errors_config_parse_config_error_for_custom_source_with_invalid_architecture_name.snap
+++ b/src/__snapshots/errors_config_parse_config_error_for_custom_source_with_invalid_architecture_name.snap
@@ -1,0 +1,52 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - Invalid architecture name found for the following custom source:
+    [[com.heroku.buildpacks.deb-packages.sources]]
+    uri = "http://archive.ubuntu.com/ubuntu"
+    suites = ["main"]
+    components = ["multiverse"]
+    arch = ["i386"]
+    signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+    
+    NxRt3Z+7w5HMIN2laKp+ItxloPWGBdcHU4o2ZnWgsVT8Y/a+RED75DDbAQ6lS3fV
+    sSlmQLExcf75qOPy34XNv3gWP4tbfIXXt8olflF8hwHggmKZzEImnzEozPabDsN7
+    nkhHZEWhGcPRcuHbFOqcirV1sfsKK1gOsTbxS00iD3OivOFCQqujF196cal/utTd
+    hVnssTC1arrx273zFepLosPvgrT0TS7tnyXbzuq5mo0zD1fSj4kuSS9V/SSy9fWF
+    LAtHiNQJkjzGFxu0/9dyQyX6C523uvfdcOzpObTyjBeGKqmEEf0lF5OYLDlkk2Sm
+    iGa6i2oLaGzGaQZDpdqyQZiYpQEYw9xN+8g=
+    =J31U
+    -----END PGP PUBLIC KEY BLOCK-----
+    """
+    
+    ---
+    Unsupported architecture name: "i386"
+    Must be one of:
+    - "amd64"
+    - "arm64"
+
+! Error parsing `/path/to/project.toml` with invalid custom source
+!
+! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` to \
+! complete the build but we found an invalid custom source in the \
+! key `[com.heroku.buildpacks.deb-packages]`.
+!
+! Custom sources must be in the following format:
+!
+! [[com.heroku.buildpacks.deb-packages.sources]]
+! uri = "<url_of_debian_repository> (e.g.; http://archive.ubuntu.com/ubuntu)"
+! suites = ["<suite> (e.g.; jammy)"]
+! components = ["<component> (e.g.; main)"]
+! arch = ["<architecture> (e.g.; amd64 or arm64)"]
+! signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+! <ASCII-armored GPG key>
+! -----END PGP PUBLIC KEY BLOCK-----
+!
+! Suggestions:
+! - See the buildpack documentation for the proper usage for this configuration at \
+! https://github.com/heroku/buildpacks-deb-packages#configuration
+! - See the TOML documentation for more details on the TOML array of tables type \
+! at https://toml.io/en/v1.0.0
+!
+! Use the debug information above to troubleshoot and retry your build.

--- a/src/__snapshots/errors_config_parse_config_error_for_custom_source_with_invalid_components.snap
+++ b/src/__snapshots/errors_config_parse_config_error_for_custom_source_with_invalid_components.snap
@@ -1,0 +1,46 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - Unexpected toml value ("123") found for the following custom source:
+    [[com.heroku.buildpacks.deb-packages.sources]]
+    uri = "http://archive.ubuntu.com/ubuntu"
+    suites = ["main"]
+    components = [123]
+    arch = ["amd64", "arm64"]
+    signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+    
+    NxRt3Z+7w5HMIN2laKp+ItxloPWGBdcHU4o2ZnWgsVT8Y/a+RED75DDbAQ6lS3fV
+    sSlmQLExcf75qOPy34XNv3gWP4tbfIXXt8olflF8hwHggmKZzEImnzEozPabDsN7
+    nkhHZEWhGcPRcuHbFOqcirV1sfsKK1gOsTbxS00iD3OivOFCQqujF196cal/utTd
+    hVnssTC1arrx273zFepLosPvgrT0TS7tnyXbzuq5mo0zD1fSj4kuSS9V/SSy9fWF
+    LAtHiNQJkjzGFxu0/9dyQyX6C523uvfdcOzpObTyjBeGKqmEEf0lF5OYLDlkk2Sm
+    iGa6i2oLaGzGaQZDpdqyQZiYpQEYw9xN+8g=
+    =J31U
+    -----END PGP PUBLIC KEY BLOCK-----
+    """
+
+! Error parsing `/path/to/project.toml` with invalid custom source
+!
+! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` to \
+! complete the build but we found an invalid custom source in the \
+! key `[com.heroku.buildpacks.deb-packages]`.
+!
+! Custom sources must be in the following format:
+!
+! [[com.heroku.buildpacks.deb-packages.sources]]
+! uri = "<url_of_debian_repository> (e.g.; http://archive.ubuntu.com/ubuntu)"
+! suites = ["<suite> (e.g.; jammy)"]
+! components = ["<component> (e.g.; main)"]
+! arch = ["<architecture> (e.g.; amd64 or arm64)"]
+! signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+! <ASCII-armored GPG key>
+! -----END PGP PUBLIC KEY BLOCK-----
+!
+! Suggestions:
+! - See the buildpack documentation for the proper usage for this configuration at \
+! https://github.com/heroku/buildpacks-deb-packages#configuration
+! - See the TOML documentation for more details on the TOML array of tables type \
+! at https://toml.io/en/v1.0.0
+!
+! Use the debug information above to troubleshoot and retry your build.

--- a/src/__snapshots/errors_config_parse_config_error_for_custom_source_with_missing_architecture_names.snap
+++ b/src/__snapshots/errors_config_parse_config_error_for_custom_source_with_missing_architecture_names.snap
@@ -1,0 +1,45 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - Missing or invalid "arch" field. One or more String values must be present for the following custom source:
+    [[com.heroku.buildpacks.deb-packages.sources]]
+    uri = "http://archive.ubuntu.com/ubuntu"
+    suites = ["main"]
+    components = ["multiverse"]
+    signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+    
+    NxRt3Z+7w5HMIN2laKp+ItxloPWGBdcHU4o2ZnWgsVT8Y/a+RED75DDbAQ6lS3fV
+    sSlmQLExcf75qOPy34XNv3gWP4tbfIXXt8olflF8hwHggmKZzEImnzEozPabDsN7
+    nkhHZEWhGcPRcuHbFOqcirV1sfsKK1gOsTbxS00iD3OivOFCQqujF196cal/utTd
+    hVnssTC1arrx273zFepLosPvgrT0TS7tnyXbzuq5mo0zD1fSj4kuSS9V/SSy9fWF
+    LAtHiNQJkjzGFxu0/9dyQyX6C523uvfdcOzpObTyjBeGKqmEEf0lF5OYLDlkk2Sm
+    iGa6i2oLaGzGaQZDpdqyQZiYpQEYw9xN+8g=
+    =J31U
+    -----END PGP PUBLIC KEY BLOCK-----
+    """
+
+! Error parsing `/path/to/project.toml` with invalid custom source
+!
+! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` to \
+! complete the build but we found an invalid custom source in the \
+! key `[com.heroku.buildpacks.deb-packages]`.
+!
+! Custom sources must be in the following format:
+!
+! [[com.heroku.buildpacks.deb-packages.sources]]
+! uri = "<url_of_debian_repository> (e.g.; http://archive.ubuntu.com/ubuntu)"
+! suites = ["<suite> (e.g.; jammy)"]
+! components = ["<component> (e.g.; main)"]
+! arch = ["<architecture> (e.g.; amd64 or arm64)"]
+! signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+! <ASCII-armored GPG key>
+! -----END PGP PUBLIC KEY BLOCK-----
+!
+! Suggestions:
+! - See the buildpack documentation for the proper usage for this configuration at \
+! https://github.com/heroku/buildpacks-deb-packages#configuration
+! - See the TOML documentation for more details on the TOML array of tables type \
+! at https://toml.io/en/v1.0.0
+!
+! Use the debug information above to troubleshoot and retry your build.

--- a/src/__snapshots/errors_config_parse_config_error_for_custom_source_with_missing_components.snap
+++ b/src/__snapshots/errors_config_parse_config_error_for_custom_source_with_missing_components.snap
@@ -1,0 +1,45 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - Missing or invalid "components" field. One or more String values must be present for the following custom source:
+    [[com.heroku.buildpacks.deb-packages.sources]]
+    uri = "http://archive.ubuntu.com/ubuntu"
+    suites = ["main"]
+    arch = ["amd64", "arm64"]
+    signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+    
+    NxRt3Z+7w5HMIN2laKp+ItxloPWGBdcHU4o2ZnWgsVT8Y/a+RED75DDbAQ6lS3fV
+    sSlmQLExcf75qOPy34XNv3gWP4tbfIXXt8olflF8hwHggmKZzEImnzEozPabDsN7
+    nkhHZEWhGcPRcuHbFOqcirV1sfsKK1gOsTbxS00iD3OivOFCQqujF196cal/utTd
+    hVnssTC1arrx273zFepLosPvgrT0TS7tnyXbzuq5mo0zD1fSj4kuSS9V/SSy9fWF
+    LAtHiNQJkjzGFxu0/9dyQyX6C523uvfdcOzpObTyjBeGKqmEEf0lF5OYLDlkk2Sm
+    iGa6i2oLaGzGaQZDpdqyQZiYpQEYw9xN+8g=
+    =J31U
+    -----END PGP PUBLIC KEY BLOCK-----
+    """
+
+! Error parsing `/path/to/project.toml` with invalid custom source
+!
+! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` to \
+! complete the build but we found an invalid custom source in the \
+! key `[com.heroku.buildpacks.deb-packages]`.
+!
+! Custom sources must be in the following format:
+!
+! [[com.heroku.buildpacks.deb-packages.sources]]
+! uri = "<url_of_debian_repository> (e.g.; http://archive.ubuntu.com/ubuntu)"
+! suites = ["<suite> (e.g.; jammy)"]
+! components = ["<component> (e.g.; main)"]
+! arch = ["<architecture> (e.g.; amd64 or arm64)"]
+! signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+! <ASCII-armored GPG key>
+! -----END PGP PUBLIC KEY BLOCK-----
+!
+! Suggestions:
+! - See the buildpack documentation for the proper usage for this configuration at \
+! https://github.com/heroku/buildpacks-deb-packages#configuration
+! - See the TOML documentation for more details on the TOML array of tables type \
+! at https://toml.io/en/v1.0.0
+!
+! Use the debug information above to troubleshoot and retry your build.

--- a/src/__snapshots/errors_config_parse_config_error_for_custom_source_with_missing_signed_by.snap
+++ b/src/__snapshots/errors_config_parse_config_error_for_custom_source_with_missing_signed_by.snap
@@ -1,0 +1,35 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - Missing or invalid "signed_by" field for the following custom source:
+    [[com.heroku.buildpacks.deb-packages.sources]]
+    uri = "http://archive.ubuntu.com/ubuntu"
+    suites = ["main"]
+    components = ["multiverse"]
+    arch = ["amd64", "arm64"]
+
+! Error parsing `/path/to/project.toml` with invalid custom source
+!
+! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` to \
+! complete the build but we found an invalid custom source in the \
+! key `[com.heroku.buildpacks.deb-packages]`.
+!
+! Custom sources must be in the following format:
+!
+! [[com.heroku.buildpacks.deb-packages.sources]]
+! uri = "<url_of_debian_repository> (e.g.; http://archive.ubuntu.com/ubuntu)"
+! suites = ["<suite> (e.g.; jammy)"]
+! components = ["<component> (e.g.; main)"]
+! arch = ["<architecture> (e.g.; amd64 or arm64)"]
+! signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+! <ASCII-armored GPG key>
+! -----END PGP PUBLIC KEY BLOCK-----
+!
+! Suggestions:
+! - See the buildpack documentation for the proper usage for this configuration at \
+! https://github.com/heroku/buildpacks-deb-packages#configuration
+! - See the TOML documentation for more details on the TOML array of tables type \
+! at https://toml.io/en/v1.0.0
+!
+! Use the debug information above to troubleshoot and retry your build.

--- a/src/__snapshots/errors_config_parse_config_error_for_custom_source_with_missing_suites.snap
+++ b/src/__snapshots/errors_config_parse_config_error_for_custom_source_with_missing_suites.snap
@@ -1,0 +1,45 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - Missing or invalid "suites" field. One or more String values must be present for the following custom source:
+    [[com.heroku.buildpacks.deb-packages.sources]]
+    uri = "http://archive.ubuntu.com/ubuntu"
+    components = ["multiverse"]
+    arch = ["amd64", "arm64"]
+    signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+    
+    NxRt3Z+7w5HMIN2laKp+ItxloPWGBdcHU4o2ZnWgsVT8Y/a+RED75DDbAQ6lS3fV
+    sSlmQLExcf75qOPy34XNv3gWP4tbfIXXt8olflF8hwHggmKZzEImnzEozPabDsN7
+    nkhHZEWhGcPRcuHbFOqcirV1sfsKK1gOsTbxS00iD3OivOFCQqujF196cal/utTd
+    hVnssTC1arrx273zFepLosPvgrT0TS7tnyXbzuq5mo0zD1fSj4kuSS9V/SSy9fWF
+    LAtHiNQJkjzGFxu0/9dyQyX6C523uvfdcOzpObTyjBeGKqmEEf0lF5OYLDlkk2Sm
+    iGa6i2oLaGzGaQZDpdqyQZiYpQEYw9xN+8g=
+    =J31U
+    -----END PGP PUBLIC KEY BLOCK-----
+    """
+
+! Error parsing `/path/to/project.toml` with invalid custom source
+!
+! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` to \
+! complete the build but we found an invalid custom source in the \
+! key `[com.heroku.buildpacks.deb-packages]`.
+!
+! Custom sources must be in the following format:
+!
+! [[com.heroku.buildpacks.deb-packages.sources]]
+! uri = "<url_of_debian_repository> (e.g.; http://archive.ubuntu.com/ubuntu)"
+! suites = ["<suite> (e.g.; jammy)"]
+! components = ["<component> (e.g.; main)"]
+! arch = ["<architecture> (e.g.; amd64 or arm64)"]
+! signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+! <ASCII-armored GPG key>
+! -----END PGP PUBLIC KEY BLOCK-----
+!
+! Suggestions:
+! - See the buildpack documentation for the proper usage for this configuration at \
+! https://github.com/heroku/buildpacks-deb-packages#configuration
+! - See the TOML documentation for more details on the TOML array of tables type \
+! at https://toml.io/en/v1.0.0
+!
+! Use the debug information above to troubleshoot and retry your build.

--- a/src/__snapshots/errors_config_parse_config_error_for_custom_source_with_missing_uri.snap
+++ b/src/__snapshots/errors_config_parse_config_error_for_custom_source_with_missing_uri.snap
@@ -1,0 +1,45 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - Missing or invalid "uri" field for the following custom source:
+    [[com.heroku.buildpacks.deb-packages.sources]]
+    suites = ["main"]
+    components = ["multiverse"]
+    arch = ["amd64", "arm64"]
+    signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+    
+    NxRt3Z+7w5HMIN2laKp+ItxloPWGBdcHU4o2ZnWgsVT8Y/a+RED75DDbAQ6lS3fV
+    sSlmQLExcf75qOPy34XNv3gWP4tbfIXXt8olflF8hwHggmKZzEImnzEozPabDsN7
+    nkhHZEWhGcPRcuHbFOqcirV1sfsKK1gOsTbxS00iD3OivOFCQqujF196cal/utTd
+    hVnssTC1arrx273zFepLosPvgrT0TS7tnyXbzuq5mo0zD1fSj4kuSS9V/SSy9fWF
+    LAtHiNQJkjzGFxu0/9dyQyX6C523uvfdcOzpObTyjBeGKqmEEf0lF5OYLDlkk2Sm
+    iGa6i2oLaGzGaQZDpdqyQZiYpQEYw9xN+8g=
+    =J31U
+    -----END PGP PUBLIC KEY BLOCK-----
+    """
+
+! Error parsing `/path/to/project.toml` with invalid custom source
+!
+! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` to \
+! complete the build but we found an invalid custom source in the \
+! key `[com.heroku.buildpacks.deb-packages]`.
+!
+! Custom sources must be in the following format:
+!
+! [[com.heroku.buildpacks.deb-packages.sources]]
+! uri = "<url_of_debian_repository> (e.g.; http://archive.ubuntu.com/ubuntu)"
+! suites = ["<suite> (e.g.; jammy)"]
+! components = ["<component> (e.g.; main)"]
+! arch = ["<architecture> (e.g.; amd64 or arm64)"]
+! signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+! <ASCII-armored GPG key>
+! -----END PGP PUBLIC KEY BLOCK-----
+!
+! Suggestions:
+! - See the buildpack documentation for the proper usage for this configuration at \
+! https://github.com/heroku/buildpacks-deb-packages#configuration
+! - See the TOML documentation for more details on the TOML array of tables type \
+! at https://toml.io/en/v1.0.0
+!
+! Use the debug information above to troubleshoot and retry your build.

--- a/src/__snapshots/errors_config_parse_config_error_for_invalid_download_url.snap
+++ b/src/__snapshots/errors_config_parse_config_error_for_invalid_download_url.snap
@@ -1,0 +1,13 @@
+---
+source: src/errors.rs
+---
+! Error parsing `/path/to/project.toml` with invalid download url
+!
+! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` to complete the build but we found an invalid download url `not a url` in the key `[com.heroku.buildpacks.deb-packages]`.
+!
+! Validation error: relative URL without a base
+!
+! Suggestions:
+! - Verify the download url is valid.
+!
+! Use the debug information above to troubleshoot and retry your build.

--- a/src/__snapshots/errors_config_parse_config_error_for_invalid_download_url_config_type.snap
+++ b/src/__snapshots/errors_config_parse_config_error_for_invalid_download_url_config_type.snap
@@ -1,0 +1,18 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - Invalid type `integer` with value `37`
+
+! Error parsing `/path/to/project.toml` with invalid download url
+!
+! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` to complete the build but we found an invalid download url in the key `[com.heroku.buildpacks.deb-packages]`.
+!
+! Download urls must either be the following TOML values:
+! - String (e.g.; "https://example.com/package-1.2.3.deb")
+!
+! Suggestions:
+! - See the buildpack documentation for the proper usage for this configuration at https://github.com/heroku/buildpacks-deb-packages#configuration
+! - See the TOML documentation for more details on the TOML string at https://toml.io/en/v1.0.0
+!
+! Use the debug information above to troubleshoot and retry your build.

--- a/src/__snapshots/errors_config_parse_config_error_for_invalid_package_name.snap
+++ b/src/__snapshots/errors_config_parse_config_error_for_invalid_package_name.snap
@@ -1,0 +1,13 @@
+---
+source: src/errors.rs
+---
+! Error parsing `/path/to/project.toml` with invalid package name
+!
+! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` to complete the build but we found an invalid package name `invalid!package!name` in the key `[com.heroku.buildpacks.deb-packages]`.
+!
+! Package names must consist only of lowercase letters (a-z), digits (0-9), plus (+) and minus (-) signs, and periods (.). Names must be at least two characters long and must start with an alphanumeric character. See https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-source
+!
+! Suggestions:
+! - Verify the package name is correct and exists for the target distribution at https://packages.ubuntu.com/
+!
+! Use the debug information above to troubleshoot and retry your build.

--- a/src/__snapshots/errors_config_parse_config_error_for_invalid_package_name_config_type.snap
+++ b/src/__snapshots/errors_config_parse_config_error_for_invalid_package_name_config_type.snap
@@ -1,0 +1,19 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - Invalid type `integer` with value `37`
+
+! Error parsing `/path/to/project.toml` with invalid package format
+!
+! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` to complete the build but we found an invalid package format in the key `[com.heroku.buildpacks.deb-packages]`.
+!
+! Packages must either be the following TOML values:
+! - String (e.g.; "package-name")
+! - Inline table (e.g.; { name = "package-name", skip_dependencies = true })
+!
+! Suggestions:
+! - See the buildpack documentation for the proper usage for this configuration at https://github.com/heroku/buildpacks-deb-packages#configuration
+! - See the TOML documentation for more details on the TOML string and inline table types at https://toml.io/en/v1.0.0
+!
+! Use the debug information above to troubleshoot and retry your build.

--- a/src/__snapshots/errors_config_parse_config_error_for_invalid_toml.snap
+++ b/src/__snapshots/errors_config_parse_config_error_for_invalid_toml.snap
@@ -1,0 +1,18 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - TOML parse error at line 1, column 12
+      |
+    1 | [com.heroku
+      |            ^
+    unclosed table, expected `]`
+
+! Error parsing `/path/to/project.toml` with invalid TOML file
+!
+! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` to complete the build but this file isn't a valid TOML file.
+!
+! Suggestions:
+! - Ensure the file follows the TOML format described at https://toml.io/en/v1.0.0
+!
+! Use the debug information above to troubleshoot and retry your build.

--- a/src/__snapshots/errors_config_parse_config_error_for_missing_namespaced_config.snap
+++ b/src/__snapshots/errors_config_parse_config_error_for_missing_namespaced_config.snap
@@ -1,0 +1,10 @@
+---
+source: src/errors.rs
+---
+! Error parsing `/path/to/project.toml` with invalid key
+!
+! The Heroku .deb Packages buildpack reads the configuration from `/path/to/project.toml` to complete the build but no configuration for the key `[com.heroku.buildpacks.deb-packages]` is present. The value of this key must be a TOML table.
+!
+! Suggestions:
+! - See the buildpack documentation for the proper usage for this configuration at https://github.com/heroku/buildpacks-deb-packages#configuration
+! - See the TOML documentation for more details on the TOML table type at https://toml.io/en/v1.0.0

--- a/src/__snapshots/errors_config_parse_config_error_for_wrong_config_type.snap
+++ b/src/__snapshots/errors_config_parse_config_error_for_wrong_config_type.snap
@@ -1,0 +1,12 @@
+---
+source: src/errors.rs
+---
+! Error parsing `/path/to/project.toml` with invalid key
+!
+! The Heroku .deb Packages buildpack reads the configuration from `/path/to/project.toml` to complete the build but the configuration for the key `[com.heroku.buildpacks.deb-packages]` isn't the correct type. The value of this key must be a TOML table.
+!
+! Suggestions:
+! - See the buildpack documentation for the proper usage for this configuration at https://github.com/heroku/buildpacks-deb-packages#configuration
+! - See the TOML documentation for more details on the TOML table type at https://toml.io/en/v1.0.0
+!
+! Use the debug information above to troubleshoot and retry your build.

--- a/src/__snapshots/errors_config_read_config_error.snap
+++ b/src/__snapshots/errors_config_read_config_error.snap
@@ -1,0 +1,14 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - test I/O error
+
+! Error reading `/path/to/project.toml`
+!
+! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` to complete the build but the file can't be read.
+!
+! Suggestions:
+! - Ensure the file has read permissions.
+!
+! Use the debug information above to troubleshoot and retry your build.

--- a/src/__snapshots/errors_create_package_index_error_checksum_failed.snap
+++ b/src/__snapshots/errors_create_package_index_error_checksum_failed.snap
@@ -1,0 +1,12 @@
+---
+source: src/errors.rs
+---
+! Package Index checksum verification failed
+!
+! While updating package sources, an error occurred while verifying the checksum of the Package Index at http://ports.ubuntu.com/ubuntu-ports/dists/noble/main/binary-arm64/by-hash/SHA256/d41d8cd98f00b204e9800998ecf8427e. This error can occur due to an issue with the upstream Debian package repository.
+!
+! Checksum:
+! - Expected: `d41d8cd98f00b204e9800998ecf8427e`
+! - Actual: `e62ff0123a74adfc6903d59a449cbdb0`
+!
+! Use the debug information above to troubleshoot and retry your build.

--- a/src/__snapshots/errors_create_package_index_error_cpu_task_failed.snap
+++ b/src/__snapshots/errors_create_package_index_error_cpu_task_failed.snap
@@ -1,0 +1,14 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - channel closed
+
+! Task failure while reading Package Index data
+!
+! A background task responsible for reading Package Index data failed to complete.
+!
+! The causes for this error are unknown. We do not have suggestions for diagnosis or a workaround at this time. You can help our understanding by sharing your buildpack log and a description of the issue at:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new
+!
+! If you're able to reproduce the problem with an example application and the `pack` build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), adding that information to the discussion will also help. Once we have more information around the causes of this error we may update this message.

--- a/src/__snapshots/errors_create_package_index_error_create_pgp_certificate.snap
+++ b/src/__snapshots/errors_create_package_index_error_create_pgp_certificate.snap
@@ -1,0 +1,18 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - Additional packets found, is this a keyring?
+
+! Failed to load verifying PGP certificate
+!
+! The PGP certificate used to verify downloaded release files failed to load. This error indicates there's a problem with the format of the certificate file the distribution uses.
+!
+! Suggestions:
+! - Verify the format of the certificates found in the ./keys directory of this buildpack's repository. See https://cirw.in/gpg-decoder
+! - Extract new certificates by running the ./scripts/extract_keys.sh script found in this buildpack's repository.
+!
+! The causes for this error are unknown. We do not have suggestions for diagnosis or a workaround at this time. You can help our understanding by sharing your buildpack log and a description of the issue at:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new
+!
+! If you're able to reproduce the problem with an example application and the `pack` build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), adding that information to the discussion will also help. Once we have more information around the causes of this error we may update this message.

--- a/src/__snapshots/errors_create_package_index_error_create_pgp_verifier.snap
+++ b/src/__snapshots/errors_create_package_index_error_create_pgp_verifier.snap
@@ -1,0 +1,17 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - Malformed OpenPGP message
+
+! Failed to verify Release file
+!
+! The PGP signature of the downloaded release file failed verification. This error can occur if the maintainers of the Debian repository changed the process for signing release files.
+!
+! Suggestions:
+! - Verify if the keys changed by running the ./scripts/extract_keys.sh script found in this buildpack's repository.
+!
+! The causes for this error are unknown. We do not have suggestions for diagnosis or a workaround at this time. You can help our understanding by sharing your buildpack log and a description of the issue at:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new
+!
+! If you're able to reproduce the problem with an example application and the `pack` build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), adding that information to the discussion will also help. Once we have more information around the causes of this error we may update this message.

--- a/src/__snapshots/errors_create_package_index_error_get_packages_request.snap
+++ b/src/__snapshots/errors_create_package_index_error_get_packages_request.snap
@@ -1,0 +1,17 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - error sending request for url (https://test/error)
+
+! Failed to request Package Index file
+!
+! While updating package sources, a request to download a Package Index file failed. This error can occur due to an unstable network connection or an issue with the upstream Debian package repository.
+!
+! Suggestions:
+! - Check the status of https://status.canonical.com/ for any reported issues.
+!
+! Use the debug information above to troubleshoot and retry your build.
+!
+! If the issue persists and you think you found a bug in the buildpack, reproduce the issue locally with a minimal example. Open an issue in the buildpack's GitHub repository and include the details here:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new

--- a/src/__snapshots/errors_create_package_index_error_get_release_request.snap
+++ b/src/__snapshots/errors_create_package_index_error_get_release_request.snap
@@ -1,0 +1,17 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - error sending request for url (https://test/error)
+
+! Failed to request Release file
+!
+! While updating package sources, a request to download a Release file failed. This error can occur due to an unstable network connection or an issue with the upstream Debian package repository.
+!
+! Suggestions:
+! - Check the status of https://status.canonical.com/ for any reported issues.
+!
+! Use the debug information above to troubleshoot and retry your build.
+!
+! If the issue persists and you think you found a bug in the buildpack, reproduce the issue locally with a minimal example. Open an issue in the buildpack's GitHub repository and include the details here:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new

--- a/src/__snapshots/errors_create_package_index_error_invalid_layer_name.snap
+++ b/src/__snapshots/errors_create_package_index_error_invalid_layer_name.snap
@@ -1,0 +1,17 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - Invalid Value: 623e1a2085e65abc3dc626a97909466ce19efe37f7a6529a842c290fcfc65b3b
+
+! Invalid layer name
+!
+! For caching purposes, a unique layer name is generated for Debian Release files and Package indices based on their download urls. The generated name for the following url was invalid:
+! - http://archive.ubuntu.com/ubuntu/dists/jammy/InRelease
+!
+! You can find the invalid layer name in the debug information above.
+!
+! The causes for this error are unknown. We do not have suggestions for diagnosis or a workaround at this time. You can help our understanding by sharing your buildpack log and a description of the issue at:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new
+!
+! If you're able to reproduce the problem with an example application and the `pack` build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), adding that information to the discussion will also help. Once we have more information around the causes of this error we may update this message.

--- a/src/__snapshots/errors_create_package_index_error_missing_package_index_release_hash.snap
+++ b/src/__snapshots/errors_create_package_index_error_missing_package_index_release_hash.snap
@@ -1,0 +1,14 @@
+---
+source: src/errors.rs
+---
+! Missing Package Index
+!
+! The Release file from http://archive.ubuntu.com/ubuntu/dists/jammy/InRelease is missing an entry for `main/binary-amd64/Packages.gz` within the SHA256 section. This error is most likely a buildpack bug but can also be an issue with the upstream repository.
+!
+! Suggestions:
+! - Verify if `main/binary-amd64/Packages.gz` is under the SHA256 section of http://archive.ubuntu.com/ubuntu/dists/jammy/InRelease
+!
+! Use the debug information above to troubleshoot and retry your build.
+!
+! If the issue persists and you think you found a bug in the buildpack, reproduce the issue locally with a minimal example. Open an issue in the buildpack's GitHub repository and include the details here:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new

--- a/src/__snapshots/errors_create_package_index_error_missing_sha256_release_hashes.snap
+++ b/src/__snapshots/errors_create_package_index_error_missing_sha256_release_hashes.snap
@@ -1,0 +1,11 @@
+---
+source: src/errors.rs
+---
+! Missing SHA256 Release hash
+!
+! The Release file from http://archive.ubuntu.com/ubuntu/dists/jammy/InRelease is missing the SHA256 key which is required according to the documented Debian repository format. This error is most likely an issue with the upstream repository. See https://wiki.debian.org/DebianRepository/Format
+!
+! Use the debug information above to troubleshoot and retry your build.
+!
+! If the issue persists and you think you found a bug in the buildpack, reproduce the issue locally with a minimal example. Open an issue in the buildpack's GitHub repository and include the details here:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new

--- a/src/__snapshots/errors_create_package_index_error_no_sources.snap
+++ b/src/__snapshots/errors_create_package_index_error_no_sources.snap
@@ -1,0 +1,11 @@
+---
+source: src/errors.rs
+---
+! No sources to update
+!
+! The distribution has no sources to update packages from.
+!
+! The causes for this error are unknown. We do not have suggestions for diagnosis or a workaround at this time. You can help our understanding by sharing your buildpack log and a description of the issue at:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new
+!
+! If you're able to reproduce the problem with an example application and the `pack` build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), adding that information to the discussion will also help. Once we have more information around the causes of this error we may update this message.

--- a/src/__snapshots/errors_create_package_index_error_parse_packages.snap
+++ b/src/__snapshots/errors_create_package_index_error_parse_packages.snap
@@ -1,0 +1,20 @@
+---
+source: src/errors.rs
+---
+! Failed to parse Package Index file
+!
+! We can't parse the Package Index file data stored in `/path/to/layer/packages-file`. This error is most likely a buildpack bug. It can also be caused by cached data that's no longer valid or an issue with the upstream repository.
+!
+! Parsing errors:
+! - There's an entry that's missing the required `Package` key.
+! - Package `package-a` is missing the required `Version` key.
+! - Package `package-b` is missing the required `Filename` key.
+! - Package `package-c` is missing the required `SHA256` key.
+!
+! Suggestions:
+! - Run the build again with a clean cache.
+!
+! The causes for this error are unknown. We do not have suggestions for diagnosis or a workaround at this time. You can help our understanding by sharing your buildpack log and a description of the issue at:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new
+!
+! If you're able to reproduce the problem with an example application and the `pack` build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), adding that information to the discussion will also help. Once we have more information around the causes of this error we may update this message.

--- a/src/__snapshots/errors_create_package_index_error_parse_release_file.snap
+++ b/src/__snapshots/errors_create_package_index_error_parse_release_file.snap
@@ -1,0 +1,17 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - Failed to parse an APT value
+
+! Failed to parse Release file data
+!
+! We couldn't parse the Release file data stored in `/path/to/layer/release-file`. This error is most likely a buildpack bug. It can also be caused by cached data that's no longer valid or an issue with the upstream repository.
+!
+! Suggestions:
+! - Run the build again with a clean cache.
+!
+! Use the debug information above to troubleshoot and retry your build.
+!
+! If the issue persists and you think you found a bug in the buildpack, reproduce the issue locally with a minimal example. Open an issue in the buildpack's GitHub repository and include the details here:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new

--- a/src/__snapshots/errors_create_package_index_error_read_get_release_response.snap
+++ b/src/__snapshots/errors_create_package_index_error_read_get_release_response.snap
@@ -1,0 +1,17 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - error sending request for url (https://test/error)
+
+! Failed to download Release file
+!
+! While updating package sources, an error occurred while downloading a Release file. This error can occur due to an unstable network connection or an issue with the upstream Debian package repository.
+!
+! Suggestions:
+! - Check the status of https://status.canonical.com/ for any reported issues.
+!
+! Use the debug information above to troubleshoot and retry your build.
+!
+! If the issue persists and you think you found a bug in the buildpack, reproduce the issue locally with a minimal example. Open an issue in the buildpack's GitHub repository and include the details here:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new

--- a/src/__snapshots/errors_create_package_index_error_read_packages_file.snap
+++ b/src/__snapshots/errors_create_package_index_error_read_packages_file.snap
@@ -1,0 +1,14 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - entity not found
+
+! Failed to read Package Index file
+!
+! An unexpected I/O error occurred while reading Package Index data from `/path/to/layer/packages-file`.
+!
+! The causes for this error are unknown. We do not have suggestions for diagnosis or a workaround at this time. You can help our understanding by sharing your buildpack log and a description of the issue at:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new
+!
+! If you're able to reproduce the problem with an example application and the `pack` build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), adding that information to the discussion will also help. Once we have more information around the causes of this error we may update this message.

--- a/src/__snapshots/errors_create_package_index_error_read_release_file.snap
+++ b/src/__snapshots/errors_create_package_index_error_read_release_file.snap
@@ -1,0 +1,14 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - not found
+
+! Failed to read Release file from layer
+!
+! An unexpected I/O error occurred while reading Release data from `/path/to/layer/release-file`.
+!
+! The causes for this error are unknown. We do not have suggestions for diagnosis or a workaround at this time. You can help our understanding by sharing your buildpack log and a description of the issue at:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new
+!
+! If you're able to reproduce the problem with an example application and the `pack` build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), adding that information to the discussion will also help. Once we have more information around the causes of this error we may update this message.

--- a/src/__snapshots/errors_create_package_index_error_task_failed.snap
+++ b/src/__snapshots/errors_create_package_index_error_task_failed.snap
@@ -1,0 +1,14 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - task <ID> panicked with message "uh oh!"
+
+! Task failure while updating sources
+!
+! A background task responsible for updating sources failed to complete.
+!
+! The causes for this error are unknown. We do not have suggestions for diagnosis or a workaround at this time. You can help our understanding by sharing your buildpack log and a description of the issue at:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new
+!
+! If you're able to reproduce the problem with an example application and the `pack` build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), adding that information to the discussion will also help. Once we have more information around the causes of this error we may update this message.

--- a/src/__snapshots/errors_create_package_index_error_write_package_index_from_response.snap
+++ b/src/__snapshots/errors_create_package_index_error_write_package_index_from_response.snap
@@ -1,0 +1,17 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - stream closed
+
+! Failed to download Package Index file
+!
+! While updating package sources, an error occurred while downloading a Package Index file to `/path/to/layer/package-index`. This error can occur due to an unstable network connection or an issue with the upstream Debian package repository.
+!
+! Suggestions:
+! - Check the status of https://status.canonical.com/ for any reported issues.
+!
+! Use the debug information above to troubleshoot and retry your build.
+!
+! If the issue persists and you think you found a bug in the buildpack, reproduce the issue locally with a minimal example. Open an issue in the buildpack's GitHub repository and include the details here:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new

--- a/src/__snapshots/errors_create_package_index_error_write_package_layer.snap
+++ b/src/__snapshots/errors_create_package_index_error_write_package_layer.snap
@@ -1,0 +1,14 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - entity already exists
+
+! Failed to write Package Index file to layer
+!
+! An unexpected I/O error occurred while writing Package Index data to `/path/to/layer/package`.
+!
+! The causes for this error are unknown. We do not have suggestions for diagnosis or a workaround at this time. You can help our understanding by sharing your buildpack log and a description of the issue at:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new
+!
+! If you're able to reproduce the problem with an example application and the `pack` build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), adding that information to the discussion will also help. Once we have more information around the causes of this error we may update this message.

--- a/src/__snapshots/errors_create_package_index_error_write_release_layer.snap
+++ b/src/__snapshots/errors_create_package_index_error_write_release_layer.snap
@@ -1,0 +1,14 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - out of memory
+
+! Failed to write Release file to layer
+!
+! An unexpected I/O error occurred while writing release data to `/path/to/layer/file`.
+!
+! The causes for this error are unknown. We do not have suggestions for diagnosis or a workaround at this time. You can help our understanding by sharing your buildpack log and a description of the issue at:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new
+!
+! If you're able to reproduce the problem with an example application and the `pack` build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), adding that information to the discussion will also help. Once we have more information around the causes of this error we may update this message.

--- a/src/__snapshots/errors_determine_packages_to_install_error_package_not_found.snap
+++ b/src/__snapshots/errors_determine_packages_to_install_error_package_not_found.snap
@@ -1,0 +1,15 @@
+---
+source: src/errors.rs
+---
+! Package not found
+!
+! We can't find `some-package` in the Package Index. If this package is listed in the packages to install for this buildpack then the name is most likely misspelled. Otherwise, it can be an issue with the upstream Debian package repository.
+!
+! Did you mean?
+! - `some-package1`
+! - `some-package2`
+!
+! Suggestions:
+! - Verify the package name is correct and exists for the target distribution at https://packages.ubuntu.com/
+!
+! Use the debug information above to troubleshoot and retry your build.

--- a/src/__snapshots/errors_determine_packages_to_install_error_package_not_found_with_no_suggestions.snap
+++ b/src/__snapshots/errors_determine_packages_to_install_error_package_not_found_with_no_suggestions.snap
@@ -1,0 +1,14 @@
+---
+source: src/errors.rs
+---
+! Package not found
+!
+! We can't find `some-package` in the Package Index. If this package is listed in the packages to install for this buildpack then the name is most likely misspelled. Otherwise, it can be an issue with the upstream Debian package repository.
+!
+! Did you mean?
+! - No similarly named packages found
+!
+! Suggestions:
+! - Verify the package name is correct and exists for the target distribution at https://packages.ubuntu.com/
+!
+! Use the debug information above to troubleshoot and retry your build.

--- a/src/__snapshots/errors_determine_packages_to_install_error_parse_system_packages.snap
+++ b/src/__snapshots/errors_determine_packages_to_install_error_parse_system_packages.snap
@@ -1,0 +1,17 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - Failed to parse APT key-value data
+    
+    Package:
+    some-package
+
+! Failed to parse system package
+!
+! An unexpected parsing error occurred while reading system packages from `/var/lib/dpkg/status`.
+!
+! The causes for this error are unknown. We do not have suggestions for diagnosis or a workaround at this time. You can help our understanding by sharing your buildpack log and a description of the issue at:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new
+!
+! If you're able to reproduce the problem with an example application and the `pack` build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), adding that information to the discussion will also help. Once we have more information around the causes of this error we may update this message.

--- a/src/__snapshots/errors_determine_packages_to_install_error_read_system_packages.snap
+++ b/src/__snapshots/errors_determine_packages_to_install_error_read_system_packages.snap
@@ -1,0 +1,14 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - entity not found
+
+! Failed to read system packages
+!
+! An unexpected I/O error occurred while reading system packages from `/var/lib/dpkg/status`.
+!
+! The causes for this error are unknown. We do not have suggestions for diagnosis or a workaround at this time. You can help our understanding by sharing your buildpack log and a description of the issue at:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new
+!
+! If you're able to reproduce the problem with an example application and the `pack` build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), adding that information to the discussion will also help. Once we have more information around the causes of this error we may update this message.

--- a/src/__snapshots/errors_determine_packages_to_install_error_virtual_package_must_be_specified.snap
+++ b/src/__snapshots/errors_determine_packages_to_install_error_virtual_package_must_be_specified.snap
@@ -1,0 +1,15 @@
+---
+source: src/errors.rs
+---
+! Multiple providers were found for the package `some-package`
+!
+! Sometimes there are several packages which offer more-or-less the same functionality. In this case, Debian repositories define a virtual package and one or more actual packages provide an implementation for this virtual package. When multiple providers are found for a requested package, this buildpack can't automatically choose which one is the desired implementation.
+!
+! Providing packages:
+! - package-a
+! - package-b
+!
+! Suggestions:
+! - Replace the virtual package `some-package` with one of the above providers.
+!
+! Use the debug information above to troubleshoot and retry your build.

--- a/src/__snapshots/errors_framework_error.snap
+++ b/src/__snapshots/errors_framework_error.snap
@@ -1,0 +1,14 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - Couldn't write build SBOM files: operation interrupted
+
+! Heroku Deb Packages Buildpack internal error
+!
+! The framework used by this buildpack encountered an unexpected error.
+!
+! If you can’t deploy to Heroku due to this issue, check the official Heroku Status page at status.heroku.com for any ongoing incidents. After all incidents resolve, retry your build.
+!
+! Use the debug information above to troubleshoot and retry your build. If you think you found a bug in the buildpack, reproduce the issue locally with a minimal example and file an issue here:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new

--- a/src/__snapshots/errors_install_packages_error_checksum_failed.snap
+++ b/src/__snapshots/errors_install_packages_error_checksum_failed.snap
@@ -1,0 +1,12 @@
+---
+source: src/errors.rs
+---
+! Package checksum verification failed
+!
+! An error occurred while verifying the checksum of the package at http://archive.ubuntu.com/ubuntu/dists/jammy/some-package.tgz. This error can occur due to an issue with the upstream Debian package repository.
+!
+! Checksum:
+! - Expected: `7931f51fd704f93171f36f5f6f1d7b7b`
+! - Actual: `19a47cdb280539511523382fa1cabbe5`
+!
+! Use the debug information above to troubleshoot and retry your build.

--- a/src/__snapshots/errors_install_packages_error_invalid_filename.snap
+++ b/src/__snapshots/errors_install_packages_error_invalid_filename.snap
@@ -1,0 +1,11 @@
+---
+source: src/errors.rs
+---
+! Could not determine file name for `some-package`
+!
+! The package information for `some-package` contains a Filename field of `..` which produces an invalid name to use as a download path.
+!
+! The causes for this error are unknown. We do not have suggestions for diagnosis or a workaround at this time. You can help our understanding by sharing your buildpack log and a description of the issue at:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new
+!
+! If you're able to reproduce the problem with an example application and the `pack` build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), adding that information to the discussion will also help. Once we have more information around the causes of this error we may update this message.

--- a/src/__snapshots/errors_install_packages_error_open_package_archive.snap
+++ b/src/__snapshots/errors_install_packages_error_open_package_archive.snap
@@ -1,0 +1,14 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - permission denied
+
+! Failed to open package archive
+!
+! An unexpected I/O error occurred while trying to open the archive at `/path/to/layer/archive-file.tgz`.
+!
+! The causes for this error are unknown. We do not have suggestions for diagnosis or a workaround at this time. You can help our understanding by sharing your buildpack log and a description of the issue at:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new
+!
+! If you're able to reproduce the problem with an example application and the `pack` build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), adding that information to the discussion will also help. Once we have more information around the causes of this error we may update this message.

--- a/src/__snapshots/errors_install_packages_error_open_package_archive_entry.snap
+++ b/src/__snapshots/errors_install_packages_error_open_package_archive_entry.snap
@@ -1,0 +1,14 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - invalid header entry
+
+! Failed to read package archive entry
+!
+! An unexpected I/O error occurred while trying to read the entries of the archive at `/path/to/layer/archive-file.tgz`.
+!
+! The causes for this error are unknown. We do not have suggestions for diagnosis or a workaround at this time. You can help our understanding by sharing your buildpack log and a description of the issue at:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new
+!
+! If you're able to reproduce the problem with an example application and the `pack` build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), adding that information to the discussion will also help. Once we have more information around the causes of this error we may update this message.

--- a/src/__snapshots/errors_install_packages_error_read_package_config.snap
+++ b/src/__snapshots/errors_install_packages_error_read_package_config.snap
@@ -1,0 +1,14 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - invalid filename
+
+! Failed to read package config file
+!
+! An unexpected I/O error occurred while reading the package config file at `/path/to/layer/pkgconfig/somepackage.pc`.
+!
+! The causes for this error are unknown. We do not have suggestions for diagnosis or a workaround at this time. You can help our understanding by sharing your buildpack log and a description of the issue at:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new
+!
+! If you're able to reproduce the problem with an example application and the `pack` build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), adding that information to the discussion will also help. Once we have more information around the causes of this error we may update this message.

--- a/src/__snapshots/errors_install_packages_error_request_package.snap
+++ b/src/__snapshots/errors_install_packages_error_request_package.snap
@@ -1,0 +1,17 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - error sending request for url (https://test/error)
+
+! Failed to request package
+!
+! While installing packages, an error occurred while downloading `some-package`. This error can occur due to an unstable network connection or an issue with the upstream Debian package repository.
+!
+! Suggestions:
+! - Check the status of https://status.canonical.com/ for any reported issues.
+!
+! Use the debug information above to troubleshoot and retry your build.
+!
+! If the issue persists and you think you found a bug in the buildpack, reproduce the issue locally with a minimal example. Open an issue in the buildpack's GitHub repository and include the details here:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new

--- a/src/__snapshots/errors_install_packages_error_request_package_url.snap
+++ b/src/__snapshots/errors_install_packages_error_request_package_url.snap
@@ -1,0 +1,17 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - error sending request for url (https://test/error)
+
+! Failed to request package from download url
+!
+! While installing packages, an error occurred while downloading the package at https://example.com/custom-package.deb. This error can occur due to an unstable network connection or an issue with site this package is hosted at.
+!
+! Suggestions:
+! - Check if https://example.com/custom-package.deb can be downloaded locally or if there's an error.
+!
+! Use the debug information above to troubleshoot and retry your build.
+!
+! If the issue persists and you think you found a bug in the buildpack, reproduce the issue locally with a minimal example. Open an issue in the buildpack's GitHub repository and include the details here:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new

--- a/src/__snapshots/errors_install_packages_error_task_failed.snap
+++ b/src/__snapshots/errors_install_packages_error_task_failed.snap
@@ -1,0 +1,14 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - task <ID> panicked with message "uh oh!"
+
+! Task failure while installing packages
+!
+! A background task responsible for installing failed to complete.
+!
+! The causes for this error are unknown. We do not have suggestions for diagnosis or a workaround at this time. You can help our understanding by sharing your buildpack log and a description of the issue at:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new
+!
+! If you're able to reproduce the problem with an example application and the `pack` build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), adding that information to the discussion will also help. Once we have more information around the causes of this error we may update this message.

--- a/src/__snapshots/errors_install_packages_error_unpack_tarball.snap
+++ b/src/__snapshots/errors_install_packages_error_unpack_tarball.snap
@@ -1,0 +1,14 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - directory not empty
+
+! Failed to unpack package archive
+!
+! An unexpected I/O error occurred while trying to unpack the archive at `/path/to/layer/archive-file.tgz`.
+!
+! The causes for this error are unknown. We do not have suggestions for diagnosis or a workaround at this time. You can help our understanding by sharing your buildpack log and a description of the issue at:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new
+!
+! If you're able to reproduce the problem with an example application and the `pack` build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), adding that information to the discussion will also help. Once we have more information around the causes of this error we may update this message.

--- a/src/__snapshots/errors_install_packages_error_unsupported_compression.snap
+++ b/src/__snapshots/errors_install_packages_error_unsupported_compression.snap
@@ -1,0 +1,11 @@
+---
+source: src/errors.rs
+---
+! Unsupported compression format for package archive
+!
+! An unexpected compression format (`lz`) was used for the package archive at `/path/to/layer/archive-file.tgz`.
+!
+! The causes for this error are unknown. We do not have suggestions for diagnosis or a workaround at this time. You can help our understanding by sharing your buildpack log and a description of the issue at:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new
+!
+! If you're able to reproduce the problem with an example application and the `pack` build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), adding that information to the discussion will also help. Once we have more information around the causes of this error we may update this message.

--- a/src/__snapshots/errors_install_packages_error_write_package.snap
+++ b/src/__snapshots/errors_install_packages_error_write_package.snap
@@ -1,0 +1,17 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - stream closed
+
+! Failed to download package
+!
+! An unexpected I/O error occured while downloading `some-package` from https://test/error to `/path/to/layer/download-file`. This error can occur due to an unstable network connection or an issue with the upstream Debian package repository.
+!
+! Suggestions:
+! - Check the status of https://status.canonical.com/ for any reported issues.
+!
+! Use the debug information above to troubleshoot and retry your build.
+!
+! If the issue persists and you think you found a bug in the buildpack, reproduce the issue locally with a minimal example. Open an issue in the buildpack's GitHub repository and include the details here:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new

--- a/src/__snapshots/errors_install_packages_error_write_package_config.snap
+++ b/src/__snapshots/errors_install_packages_error_write_package_config.snap
@@ -1,0 +1,14 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - operation interrupted
+
+! Failed to write package config file
+!
+! An unexpected I/O error occurred while writing the package config file to `/path/to/layer/pkgconfig/somepackage.pc`.
+!
+! The causes for this error are unknown. We do not have suggestions for diagnosis or a workaround at this time. You can help our understanding by sharing your buildpack log and a description of the issue at:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new
+!
+! If you're able to reproduce the problem with an example application and the `pack` build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), adding that information to the discussion will also help. Once we have more information around the causes of this error we may update this message.

--- a/src/__snapshots/errors_install_packages_error_write_package_url.snap
+++ b/src/__snapshots/errors_install_packages_error_write_package_url.snap
@@ -1,0 +1,17 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - connection reset
+
+! Failed to download package
+!
+! An unexpected I/O error occured while downloading the package at https://example.com/custom-package.deb to `/path/to/layer/custom-package.deb`. This error can occur due to an unstable network connection or an issue with the site this packages is hosted at.
+!
+! Suggestions:
+! - Check if https://example.com/custom-package.deb can be downloaded locally or if there's an error.
+!
+! Use the debug information above to troubleshoot and retry your build.
+!
+! If the issue persists and you think you found a bug in the buildpack, reproduce the issue locally with a minimal example. Open an issue in the buildpack's GitHub repository and include the details here:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new

--- a/src/__snapshots/errors_test_detect_check_exists_aptfile_error.snap
+++ b/src/__snapshots/errors_test_detect_check_exists_aptfile_error.snap
@@ -1,0 +1,11 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - test I/O error
+
+! Unable to complete buildpack detection
+!
+! An unexpected I/O error occurred while checking `/path/to/Aptfile` to determine if the Heroku .deb Packages buildpack is compatible for this application.
+!
+! Use the debug information above to troubleshoot and retry your build.

--- a/src/__snapshots/errors_test_detect_check_exists_project_toml_error.snap
+++ b/src/__snapshots/errors_test_detect_check_exists_project_toml_error.snap
@@ -1,0 +1,11 @@
+---
+source: src/errors.rs
+---
+- Debug Info:
+  - test I/O error
+
+! Unable to complete buildpack detection
+!
+! An unexpected I/O error occurred while checking `/path/to/project.toml` to determine if the Heroku .deb Packages buildpack is compatible for this application.
+!
+! Use the debug information above to troubleshoot and retry your build.

--- a/src/__snapshots/errors_unsupported_distro_error.snap
+++ b/src/__snapshots/errors_unsupported_distro_error.snap
@@ -1,0 +1,11 @@
+---
+source: src/errors.rs
+---
+! Unsupported distribution
+!
+! The Heroku .deb Packages buildpack doesn't support the Windows XP (x86) distribution. See `buildpack.toml` for the configuration of supported distributions.
+!
+! The causes for this error are unknown. We do not have suggestions for diagnosis or a workaround at this time. You can help our understanding by sharing your buildpack log and a description of the issue at:
+! https://github.com/heroku/buildpacks-deb-packages/issues/new
+!
+! If you're able to reproduce the problem with an example application and the `pack` build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), adding that information to the discussion will also help. Once we have more information around the causes of this error we may update this message.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -9,10 +9,10 @@ use crate::install_packages::InstallPackagesError;
 use crate::{DebianPackagesBuildpackError, DetectError};
 use bon::builder;
 use bullet_stream::{Print, global::print, style};
-use std::fmt;
 use indoc::{formatdoc, indoc};
 use libcnb::Error;
 use std::collections::BTreeSet;
+use std::fmt;
 use std::path::Path;
 
 const BUILDPACK_NAME: &str = "Heroku .deb Packages buildpack";
@@ -1050,7 +1050,6 @@ enum SuggestSubmitIssue {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::DebianPackagesBuildpackError::UnsupportedDistro;
     use crate::config::download_url::DownloadUrl;
     use crate::debian::{
         ParsePackageNameError, ParseRepositoryPackageError, RepositoryPackage, RepositoryUri,
@@ -1058,530 +1057,134 @@ mod tests {
     };
     use anyhow::anyhow;
     use bullet_stream::strip_ansi;
+    use insta::{assert_snapshot, with_settings};
     use libcnb::data::layer::LayerNameError;
-    use libcnb_test::assert_contains_match;
     use reqwest::Url;
     use std::collections::HashSet;
+    use std::path::PathBuf;
     use std::str::FromStr;
     use toml_edit::Table;
 
     #[test]
     fn test_detect_check_exists_project_toml_error() {
-        test_error_output(
-            "
-                Context
-                -------
-                When detect is executed on this buildpack, we check to see if a project.toml
-                file exists since that's where configuration for this buildpack would be found.
-                I/O operations can fail for a number of reasons which we can't anticipate and
-                the best we can do here is report the error message.
-            ",
-            DetectError::CheckExistsProjectToml(
-                "/path/to/project.toml".into(),
-                create_io_error("test I/O error"),
-            ),
-            indoc! {"
-                - Debug Info:
-                  - test I/O error
-
-                ! Unable to complete buildpack detection
-                !
-                ! An unexpected I/O error occurred while checking `/path/to/project.toml` to \
-                determine if the Heroku .deb Packages buildpack is compatible for this application.
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
-            "},
-        );
+        assert_error_snapshot(&on_detect_error(DetectError::CheckExistsProjectToml(
+            "/path/to/project.toml".into(),
+            create_io_error("test I/O error"),
+        )));
     }
 
     #[test]
     fn test_detect_check_exists_aptfile_error() {
-        test_error_output(
-            "
-                Context
-                -------
-                When detect is executed on this buildpack, we check to see if an Aptfile
-                exists since that's where configuration for the non-CNB variant of this
-                buildpack would be found so we can display a migration message to the user.
-                I/O operations can fail for a number of reasons which we can't anticipate and
-                the best we can do here is report the error message.
-            ",
-            DetectError::CheckExistsAptfile(
-                "/path/to/Aptfile".into(),
-                create_io_error("test I/O error"),
-            ),
-            indoc! {"
-                - Debug Info:
-                  - test I/O error
-
-                ! Unable to complete buildpack detection
-                !
-                ! An unexpected I/O error occurred while checking `/path/to/Aptfile` to \
-                determine if the Heroku .deb Packages buildpack is compatible for this application.
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
-            "},
-        );
+        assert_error_snapshot(&on_detect_error(DetectError::CheckExistsAptfile(
+            "/path/to/Aptfile".into(),
+            create_io_error("test I/O error"),
+        )));
     }
 
     #[test]
     fn config_read_config_error() {
-        test_error_output(
-            "
-                Context
-                -------
-                We read the buildpack configuration from project.toml. I/O operations can fail
-                for a number of reasons which we can't anticipate but the most likely one here would
-                be that we don't have read permissions.
-            ",
-            ConfigError::ReadConfig(
-                "/path/to/project.toml".into(),
-                create_io_error("test I/O error"),
-            ),
-            indoc! {"
-                - Debug Info:
-                  - test I/O error
-
-                ! Error reading `/path/to/project.toml`
-                !
-                ! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` \
-                to complete the build but the file can't be read.
-                !
-                ! Suggestions:
-                ! - Ensure the file has read permissions.
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
-            "},
-        );
+        assert_error_snapshot(&on_config_error(ConfigError::ReadConfig(
+            "/path/to/project.toml".into(),
+            create_io_error("test I/O error"),
+        )));
     }
 
     #[test]
     fn config_parse_config_error_for_wrong_config_type() {
-        test_error_output("
-                Context
-                -------
-                We read the buildpack configuration from project.toml which must be a valid TOML file.
-                If the file is valid but the value supplied using the configuration key for this buildpack
-                is not a TOML table then the configuration is incorrect and we can provide details to the
-                user on how they can fix this.
-            ",
-                          ConfigError::ParseConfig(
-                              "/path/to/project.toml".into(),
-                              ParseConfigError::WrongConfigType,
-                          ),
-                          indoc! {"
-                ! Error parsing `/path/to/project.toml` with invalid key
-                !
-                ! The Heroku .deb Packages buildpack reads the configuration from `/path/to/project.toml` \
-                to complete the build but the configuration for the key `[com.heroku.buildpacks.deb-packages]` \
-                isn't the correct type. The value of this key must be a TOML table.
-                !
-                ! Suggestions:
-                ! - See the buildpack documentation for the proper usage for this configuration at \
-                https://github.com/heroku/buildpacks-deb-packages#configuration
-                ! - See the TOML documentation for more details on the TOML table type at \
-                https://toml.io/en/v1.0.0
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
-            "},
-        );
+        assert_error_snapshot(&on_config_error(ConfigError::ParseConfig(
+            "/path/to/project.toml".into(),
+            ParseConfigError::WrongConfigType,
+        )));
     }
 
     #[test]
     fn config_parse_config_error_for_invalid_toml() {
-        test_error_output("
-                Context
-                -------
-                We read the buildpack configuration from project.toml which must be a valid TOML file.
-                This error will be reported if the file is not valid TOML.
-            ",
-                          ConfigError::ParseConfig(
-                              "/path/to/project.toml".into(),
-                              ParseConfigError::InvalidToml(
-                                  toml_edit::DocumentMut::from_str("[com.heroku").unwrap_err(),
-                              ),
-                          ),
-                          indoc! {"
-                - Debug Info:
-                  - TOML parse error at line 1, column 12
-                      |
-                    1 | [com.heroku
-                      |            ^
-                    unclosed table, expected `]`
-
-                ! Error parsing `/path/to/project.toml` with invalid TOML file
-                !
-                ! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` \
-                to complete the build but this file isn't a valid TOML file.
-                !
-                ! Suggestions:
-                ! - Ensure the file follows the TOML format described at https://toml.io/en/v1.0.0
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
-            "},
-        );
+        assert_error_snapshot(&on_config_error(ConfigError::ParseConfig(
+            "/path/to/project.toml".into(),
+            ParseConfigError::InvalidToml(
+                toml_edit::DocumentMut::from_str("[com.heroku").unwrap_err(),
+            ),
+        )));
     }
 
     #[test]
     fn config_parse_config_error_for_invalid_package_name() {
-        test_error_output("
-                Context
-                -------
-                We read the buildpack configuration from project.toml which must be a valid TOML file.
-                If the file is valid but the value supplied using the configuration for this buildpack
-                contains a package name that would be invalid according to Debian package naming policies,
-                we report this package name to the user and ask them to verify it.
-            ",
-                          ConfigError::ParseConfig(
-                              "/path/to/project.toml".into(),
-                              ParseConfigError::ParseRequestedPackage(
-                                  Box::from(ParseRequestedPackageError::InvalidPackageName(ParsePackageNameError {
-                                      package_name: "invalid!package!name".to_string(),
-                                  })),
-                              ),
-                          ),
-                          indoc! {"
-                ! Error parsing `/path/to/project.toml` with invalid package name
-                !
-                ! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` \
-                to complete the build but we found an invalid package name `invalid!package!name` \
-                in the key `[com.heroku.buildpacks.deb-packages]`.
-                !
-                ! Package names must consist only of lowercase letters (a-z), digits (0-9), plus (+) \
-                and minus (-) signs, and periods (.). Names must be at least two characters long and \
-                must start with an alphanumeric character. \
-                See https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-source
-                !
-                ! Suggestions:
-                ! - Verify the package name is correct and exists for the target distribution at https://packages.ubuntu.com/
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
-            "},
-        );
+        assert_error_snapshot(&on_config_error(ConfigError::ParseConfig(
+            "/path/to/project.toml".into(),
+            ParseConfigError::ParseRequestedPackage(Box::from(
+                ParseRequestedPackageError::InvalidPackageName(ParsePackageNameError {
+                    package_name: "invalid!package!name".to_string(),
+                }),
+            )),
+        )));
     }
 
     #[test]
     fn config_parse_config_error_for_invalid_package_name_config_type() {
-        test_error_output("
-                Context
-                -------
-                We read the buildpack configuration from project.toml which must be a valid TOML file.
-                If the file is valid but the value supplied using the configuration for this buildpack
-                contains a package entry that is neither a string nor inline table value, it is invalid.
-                We report this to the user and request they check the buildpack documentation for proper
-                usage.
-            ",
-                          ConfigError::ParseConfig(
-                              "/path/to/project.toml".into(),
-                              ParseConfigError::ParseRequestedPackage(
-                                  Box::from(ParseRequestedPackageError::UnexpectedTomlValue(
-                                      toml_edit::value(37).into_value().unwrap(),
-                                  )),
-                              ),
-                          ),
-                          indoc! {"
-                - Debug Info:
-                  - Invalid type `integer` with value `37`
-
-                ! Error parsing `/path/to/project.toml` with invalid package format
-                !
-                ! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` \
-                to complete the build but we found an invalid package format in the key \
-                `[com.heroku.buildpacks.deb-packages]`.
-                !
-                ! Packages must either be the following TOML values:
-                ! - String (e.g.; \"package-name\")
-                ! - Inline table (e.g.; { name = \"package-name\", skip_dependencies = true })
-                !
-                ! Suggestions:
-                ! - See the buildpack documentation for the proper usage for this configuration at \
-                https://github.com/heroku/buildpacks-deb-packages#configuration
-                ! - See the TOML documentation for more details on the TOML string and inline \
-                table types at https://toml.io/en/v1.0.0
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
-            "},
-        );
+        assert_error_snapshot(&on_config_error(ConfigError::ParseConfig(
+            "/path/to/project.toml".into(),
+            ParseConfigError::ParseRequestedPackage(Box::from(
+                ParseRequestedPackageError::UnexpectedTomlValue(
+                    toml_edit::value(37).into_value().unwrap(),
+                ),
+            )),
+        )));
     }
 
     #[test]
     fn config_parse_config_error_for_missing_namespaced_config() {
-        test_error_output(
-            "
-                Context
-                -------
-                We read the buildpack configuration from project.toml which must be a valid TOML file.
-                If the file is valid but the there is no configuration supplied, we report this to the
-                user and request they check the buildpack documentation for proper usage.
-            ",
-            ConfigError::ParseConfig(
-                "/path/to/project.toml".into(),
-                ParseConfigError::MissingNamespacedConfig,
-            ),
-            indoc! {"
-                ! Error parsing `/path/to/project.toml` with invalid key
-                !
-                ! The Heroku .deb Packages buildpack reads the configuration from `/path/to/project.toml` \
-                to complete the build but no configuration for the key `[com.heroku.buildpacks.deb-packages]` \
-                is present. The value of this key must be a TOML table.
-                !
-                ! Suggestions:
-                ! - See the buildpack documentation for the proper usage for this configuration at https://github.com/heroku/buildpacks-deb-packages#configuration
-                ! - See the TOML documentation for more details on the TOML table type at https://toml.io/en/v1.0.0
-        "},
-        );
+        assert_error_snapshot(&on_config_error(ConfigError::ParseConfig(
+            "/path/to/project.toml".into(),
+            ParseConfigError::MissingNamespacedConfig,
+        )));
     }
 
     #[test]
     fn config_parse_config_error_for_custom_source_with_missing_uri() {
         let mut table = create_custom_source_table();
         table.remove("uri");
-        test_error_output(
-            "
-                Context
-                -------
-                We read the buildpack configuration from project.toml which must be a valid TOML file.
-                If the file is valid but the value supplied using the configuration for this buildpack
-                contains a custom source that is missing the 'uri' field, it is invalid.
-                We report this to the user and request they check the buildpack documentation for proper
-                usage.
-            ",
-            ConfigError::ParseConfig(
-                "/path/to/project.toml".into(),
-                ParseConfigError::ParseCustomSource(Box::from(ParseCustomSourceError::MissingUri(table))),
-            ),
-            &formatdoc! { r#"
-                - Debug Info:
-                  - Missing or invalid "uri" field for the following custom source:
-                    [[com.heroku.buildpacks.deb-packages.sources]]
-                    suites = ["main"]
-                    components = ["multiverse"]
-                    arch = ["amd64", "arm64"]
-                    signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
-
-                    NxRt3Z+7w5HMIN2laKp+ItxloPWGBdcHU4o2ZnWgsVT8Y/a+RED75DDbAQ6lS3fV
-                    sSlmQLExcf75qOPy34XNv3gWP4tbfIXXt8olflF8hwHggmKZzEImnzEozPabDsN7
-                    nkhHZEWhGcPRcuHbFOqcirV1sfsKK1gOsTbxS00iD3OivOFCQqujF196cal/utTd
-                    hVnssTC1arrx273zFepLosPvgrT0TS7tnyXbzuq5mo0zD1fSj4kuSS9V/SSy9fWF
-                    LAtHiNQJkjzGFxu0/9dyQyX6C523uvfdcOzpObTyjBeGKqmEEf0lF5OYLDlkk2Sm
-                    iGa6i2oLaGzGaQZDpdqyQZiYpQEYw9xN+8g=
-                    =J31U
-                    -----END PGP PUBLIC KEY BLOCK-----
-                    """
-
-                ! Error parsing `/path/to/project.toml` with invalid custom source
-                !
-                ! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` to \
-                ! complete the build but we found an invalid custom source in the \
-                ! key `[com.heroku.buildpacks.deb-packages]`.
-                !
-                ! Custom sources must be in the following format:
-                !
-                ! [[com.heroku.buildpacks.deb-packages.sources]]
-                ! uri = "<url_of_debian_repository> (e.g.; http://archive.ubuntu.com/ubuntu)"
-                ! suites = ["<suite> (e.g.; jammy)"]
-                ! components = ["<component> (e.g.; main)"]
-                ! arch = ["<architecture> (e.g.; amd64 or arm64)"]
-                ! signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
-                ! <ASCII-armored GPG key>
-                ! -----END PGP PUBLIC KEY BLOCK-----
-                !
-                ! Suggestions:
-                ! - See the buildpack documentation for the proper usage for this configuration at \
-                ! https://github.com/heroku/buildpacks-deb-packages#configuration
-                ! - See the TOML documentation for more details on the TOML array of tables type \
-                ! at https://toml.io/en/v1.0.0
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
-        "#},
-        );
+        assert_error_snapshot(&on_config_error(ConfigError::ParseConfig(
+            "/path/to/project.toml".into(),
+            ParseConfigError::ParseCustomSource(Box::from(ParseCustomSourceError::MissingUri(
+                table,
+            ))),
+        )));
     }
 
     #[test]
     fn config_parse_config_error_for_custom_source_with_missing_signed_by() {
         let mut table = create_custom_source_table();
         table.remove("signed_by");
-        test_error_output(
-            "
-                Context
-                -------
-                We read the buildpack configuration from project.toml which must be a valid TOML file.
-                If the file is valid but the value supplied using the configuration for this buildpack
-                contains a custom source that is missing the 'signed_by' field, it is invalid.
-                We report this to the user and request they check the buildpack documentation for proper
-                usage.
-            ",
-            ConfigError::ParseConfig(
-                "/path/to/project.toml".into(),
-                ParseConfigError::ParseCustomSource(Box::from(ParseCustomSourceError::MissingSignedBy(table))),
-            ),
-            &formatdoc! { r#"
-                - Debug Info:
-                  - Missing or invalid "signed_by" field for the following custom source:
-                    [[com.heroku.buildpacks.deb-packages.sources]]
-                    uri = "http://archive.ubuntu.com/ubuntu"
-                    suites = ["main"]
-                    components = ["multiverse"]
-                    arch = ["amd64", "arm64"]
-
-                ! Error parsing `/path/to/project.toml` with invalid custom source
-                !
-                ! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` to \
-                ! complete the build but we found an invalid custom source in the \
-                ! key `[com.heroku.buildpacks.deb-packages]`.
-                !
-                ! Custom sources must be in the following format:
-                !
-                ! [[com.heroku.buildpacks.deb-packages.sources]]
-                ! uri = "<url_of_debian_repository> (e.g.; http://archive.ubuntu.com/ubuntu)"
-                ! suites = ["<suite> (e.g.; jammy)"]
-                ! components = ["<component> (e.g.; main)"]
-                ! arch = ["<architecture> (e.g.; amd64 or arm64)"]
-                ! signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
-                ! <ASCII-armored GPG key>
-                ! -----END PGP PUBLIC KEY BLOCK-----
-                !
-                ! Suggestions:
-                ! - See the buildpack documentation for the proper usage for this configuration at \
-                ! https://github.com/heroku/buildpacks-deb-packages#configuration
-                ! - See the TOML documentation for more details on the TOML array of tables type \
-                ! at https://toml.io/en/v1.0.0
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
-        "#},
-        );
+        assert_error_snapshot(&on_config_error(ConfigError::ParseConfig(
+            "/path/to/project.toml".into(),
+            ParseConfigError::ParseCustomSource(Box::from(
+                ParseCustomSourceError::MissingSignedBy(table),
+            )),
+        )));
     }
 
     #[test]
     fn config_parse_config_error_for_custom_source_with_missing_suites() {
         let mut table = create_custom_source_table();
         table.remove("suites");
-        test_error_output(
-            "
-                Context
-                -------
-                We read the buildpack configuration from project.toml which must be a valid TOML file.
-                If the file is valid but the value supplied using the configuration for this buildpack
-                contains a custom source that is missing the 'suites' field or the field contains
-                non-string values, it is invalid.
-                We report this to the user and request they check the buildpack documentation for proper
-                usage.
-            ",
-            ConfigError::ParseConfig(
-                "/path/to/project.toml".into(),
-                ParseConfigError::ParseCustomSource(Box::from(ParseCustomSourceError::MissingSuites(table))),
-            ),
-            &formatdoc! { r#"
-                - Debug Info:
-                  - Missing or invalid "suites" field. One or more String values must be present for the following custom source:
-                    [[com.heroku.buildpacks.deb-packages.sources]]
-                    uri = "http://archive.ubuntu.com/ubuntu"
-                    components = ["multiverse"]
-                    arch = ["amd64", "arm64"]
-                    signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
-
-                    NxRt3Z+7w5HMIN2laKp+ItxloPWGBdcHU4o2ZnWgsVT8Y/a+RED75DDbAQ6lS3fV
-                    sSlmQLExcf75qOPy34XNv3gWP4tbfIXXt8olflF8hwHggmKZzEImnzEozPabDsN7
-                    nkhHZEWhGcPRcuHbFOqcirV1sfsKK1gOsTbxS00iD3OivOFCQqujF196cal/utTd
-                    hVnssTC1arrx273zFepLosPvgrT0TS7tnyXbzuq5mo0zD1fSj4kuSS9V/SSy9fWF
-                    LAtHiNQJkjzGFxu0/9dyQyX6C523uvfdcOzpObTyjBeGKqmEEf0lF5OYLDlkk2Sm
-                    iGa6i2oLaGzGaQZDpdqyQZiYpQEYw9xN+8g=
-                    =J31U
-                    -----END PGP PUBLIC KEY BLOCK-----
-                    """
-
-                ! Error parsing `/path/to/project.toml` with invalid custom source
-                !
-                ! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` to \
-                ! complete the build but we found an invalid custom source in the \
-                ! key `[com.heroku.buildpacks.deb-packages]`.
-                !
-                ! Custom sources must be in the following format:
-                !
-                ! [[com.heroku.buildpacks.deb-packages.sources]]
-                ! uri = "<url_of_debian_repository> (e.g.; http://archive.ubuntu.com/ubuntu)"
-                ! suites = ["<suite> (e.g.; jammy)"]
-                ! components = ["<component> (e.g.; main)"]
-                ! arch = ["<architecture> (e.g.; amd64 or arm64)"]
-                ! signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
-                ! <ASCII-armored GPG key>
-                ! -----END PGP PUBLIC KEY BLOCK-----
-                !
-                ! Suggestions:
-                ! - See the buildpack documentation for the proper usage for this configuration at \
-                ! https://github.com/heroku/buildpacks-deb-packages#configuration
-                ! - See the TOML documentation for more details on the TOML array of tables type \
-                ! at https://toml.io/en/v1.0.0
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
-        "#},
-        );
+        assert_error_snapshot(&on_config_error(ConfigError::ParseConfig(
+            "/path/to/project.toml".into(),
+            ParseConfigError::ParseCustomSource(Box::from(ParseCustomSourceError::MissingSuites(
+                table,
+            ))),
+        )));
     }
 
     #[test]
     fn config_parse_config_error_for_custom_source_with_missing_components() {
         let mut table = create_custom_source_table();
         table.remove("components");
-        test_error_output(
-            "
-                Context
-                -------
-                We read the buildpack configuration from project.toml which must be a valid TOML file.
-                If the file is valid but the value supplied using the configuration for this buildpack
-                contains a custom source that is missing the 'components' field or the field contains
-                non-string values, it is invalid.
-                We report this to the user and request they check the buildpack documentation for proper
-                usage.
-            ",
-            ConfigError::ParseConfig(
-                "/path/to/project.toml".into(),
-                ParseConfigError::ParseCustomSource(Box::from(ParseCustomSourceError::MissingComponents(table))),
-            ),
-            &formatdoc! { r#"
-                - Debug Info:
-                  - Missing or invalid "components" field. One or more String values must be present for the following custom source:
-                    [[com.heroku.buildpacks.deb-packages.sources]]
-                    uri = "http://archive.ubuntu.com/ubuntu"
-                    suites = ["main"]
-                    arch = ["amd64", "arm64"]
-                    signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
-
-                    NxRt3Z+7w5HMIN2laKp+ItxloPWGBdcHU4o2ZnWgsVT8Y/a+RED75DDbAQ6lS3fV
-                    sSlmQLExcf75qOPy34XNv3gWP4tbfIXXt8olflF8hwHggmKZzEImnzEozPabDsN7
-                    nkhHZEWhGcPRcuHbFOqcirV1sfsKK1gOsTbxS00iD3OivOFCQqujF196cal/utTd
-                    hVnssTC1arrx273zFepLosPvgrT0TS7tnyXbzuq5mo0zD1fSj4kuSS9V/SSy9fWF
-                    LAtHiNQJkjzGFxu0/9dyQyX6C523uvfdcOzpObTyjBeGKqmEEf0lF5OYLDlkk2Sm
-                    iGa6i2oLaGzGaQZDpdqyQZiYpQEYw9xN+8g=
-                    =J31U
-                    -----END PGP PUBLIC KEY BLOCK-----
-                    """
-
-                ! Error parsing `/path/to/project.toml` with invalid custom source
-                !
-                ! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` to \
-                ! complete the build but we found an invalid custom source in the \
-                ! key `[com.heroku.buildpacks.deb-packages]`.
-                !
-                ! Custom sources must be in the following format:
-                !
-                ! [[com.heroku.buildpacks.deb-packages.sources]]
-                ! uri = "<url_of_debian_repository> (e.g.; http://archive.ubuntu.com/ubuntu)"
-                ! suites = ["<suite> (e.g.; jammy)"]
-                ! components = ["<component> (e.g.; main)"]
-                ! arch = ["<architecture> (e.g.; amd64 or arm64)"]
-                ! signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
-                ! <ASCII-armored GPG key>
-                ! -----END PGP PUBLIC KEY BLOCK-----
-                !
-                ! Suggestions:
-                ! - See the buildpack documentation for the proper usage for this configuration at \
-                ! https://github.com/heroku/buildpacks-deb-packages#configuration
-                ! - See the TOML documentation for more details on the TOML array of tables type \
-                ! at https://toml.io/en/v1.0.0
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
-        "#},
-        );
+        assert_error_snapshot(&on_config_error(ConfigError::ParseConfig(
+            "/path/to/project.toml".into(),
+            ParseConfigError::ParseCustomSource(Box::from(
+                ParseCustomSourceError::MissingComponents(table),
+            )),
+        )));
     }
 
     #[test]
@@ -1593,133 +1196,27 @@ mod tests {
             "components",
             toml_edit::Item::Value(toml_edit::Value::from(components)),
         );
-        test_error_output(
-            "
-                Context
-                -------
-                We read the buildpack configuration from project.toml which must be a valid TOML file.
-                If the file is valid but the value supplied using the configuration for this buildpack
-                contains a custom source that is missing the 'components' field or the field contains
-                non-string values, it is invalid.
-                We report this to the user and request they check the buildpack documentation for proper
-                usage.
-            ",
-            ConfigError::ParseConfig(
-                "/path/to/project.toml".into(),
-                ParseConfigError::ParseCustomSource(Box::from(ParseCustomSourceError::UnexpectedTomlValue(table, toml_edit::value(123).into_value().unwrap()))),
-            ),
-            &formatdoc! { r#"
-                - Debug Info:
-                  - Unexpected toml value ("123") found for the following custom source:
-                    [[com.heroku.buildpacks.deb-packages.sources]]
-                    uri = "http://archive.ubuntu.com/ubuntu"
-                    suites = ["main"]
-                    components = [123]
-                    arch = ["amd64", "arm64"]
-                    signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
-
-                    NxRt3Z+7w5HMIN2laKp+ItxloPWGBdcHU4o2ZnWgsVT8Y/a+RED75DDbAQ6lS3fV
-                    sSlmQLExcf75qOPy34XNv3gWP4tbfIXXt8olflF8hwHggmKZzEImnzEozPabDsN7
-                    nkhHZEWhGcPRcuHbFOqcirV1sfsKK1gOsTbxS00iD3OivOFCQqujF196cal/utTd
-                    hVnssTC1arrx273zFepLosPvgrT0TS7tnyXbzuq5mo0zD1fSj4kuSS9V/SSy9fWF
-                    LAtHiNQJkjzGFxu0/9dyQyX6C523uvfdcOzpObTyjBeGKqmEEf0lF5OYLDlkk2Sm
-                    iGa6i2oLaGzGaQZDpdqyQZiYpQEYw9xN+8g=
-                    =J31U
-                    -----END PGP PUBLIC KEY BLOCK-----
-                    """
-
-                ! Error parsing `/path/to/project.toml` with invalid custom source
-                !
-                ! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` to \
-                ! complete the build but we found an invalid custom source in the \
-                ! key `[com.heroku.buildpacks.deb-packages]`.
-                !
-                ! Custom sources must be in the following format:
-                !
-                ! [[com.heroku.buildpacks.deb-packages.sources]]
-                ! uri = "<url_of_debian_repository> (e.g.; http://archive.ubuntu.com/ubuntu)"
-                ! suites = ["<suite> (e.g.; jammy)"]
-                ! components = ["<component> (e.g.; main)"]
-                ! arch = ["<architecture> (e.g.; amd64 or arm64)"]
-                ! signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
-                ! <ASCII-armored GPG key>
-                ! -----END PGP PUBLIC KEY BLOCK-----
-                !
-                ! Suggestions:
-                ! - See the buildpack documentation for the proper usage for this configuration at \
-                ! https://github.com/heroku/buildpacks-deb-packages#configuration
-                ! - See the TOML documentation for more details on the TOML array of tables type \
-                ! at https://toml.io/en/v1.0.0
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
-        "#},
-        );
+        assert_error_snapshot(&on_config_error(ConfigError::ParseConfig(
+            "/path/to/project.toml".into(),
+            ParseConfigError::ParseCustomSource(Box::from(
+                ParseCustomSourceError::UnexpectedTomlValue(
+                    table,
+                    toml_edit::value(123).into_value().unwrap(),
+                ),
+            )),
+        )));
     }
 
     #[test]
     fn config_parse_config_error_for_custom_source_with_missing_architecture_names() {
         let mut table = create_custom_source_table();
         table.remove("arch");
-        test_error_output(
-            "
-                Context
-                -------
-                We read the buildpack configuration from project.toml which must be a valid TOML file.
-                If the file is valid but the value supplied using the configuration for this buildpack
-                contains a custom source that is missing the 'arch' field or the field contains
-                non-string values or unsupported architecture names, it is invalid.
-                We report this to the user and request they check the buildpack documentation for proper
-                usage.
-            ",
-            ConfigError::ParseConfig(
-                "/path/to/project.toml".into(),
-                ParseConfigError::ParseCustomSource(Box::from(ParseCustomSourceError::MissingArchitectureNames(table))),
-            ),
-            &formatdoc! { r#"
-                - Debug Info:
-                  - Missing or invalid "arch" field. One or more String values must be present for the following custom source:
-                    [[com.heroku.buildpacks.deb-packages.sources]]
-                    uri = "http://archive.ubuntu.com/ubuntu"
-                    suites = ["main"]
-                    components = ["multiverse"]
-                    signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
-
-                    NxRt3Z+7w5HMIN2laKp+ItxloPWGBdcHU4o2ZnWgsVT8Y/a+RED75DDbAQ6lS3fV
-                    sSlmQLExcf75qOPy34XNv3gWP4tbfIXXt8olflF8hwHggmKZzEImnzEozPabDsN7
-                    nkhHZEWhGcPRcuHbFOqcirV1sfsKK1gOsTbxS00iD3OivOFCQqujF196cal/utTd
-                    hVnssTC1arrx273zFepLosPvgrT0TS7tnyXbzuq5mo0zD1fSj4kuSS9V/SSy9fWF
-                    LAtHiNQJkjzGFxu0/9dyQyX6C523uvfdcOzpObTyjBeGKqmEEf0lF5OYLDlkk2Sm
-                    iGa6i2oLaGzGaQZDpdqyQZiYpQEYw9xN+8g=
-                    =J31U
-                    -----END PGP PUBLIC KEY BLOCK-----
-                    """
-
-                ! Error parsing `/path/to/project.toml` with invalid custom source
-                !
-                ! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` to \
-                ! complete the build but we found an invalid custom source in the \
-                ! key `[com.heroku.buildpacks.deb-packages]`.
-                !
-                ! Custom sources must be in the following format:
-                !
-                ! [[com.heroku.buildpacks.deb-packages.sources]]
-                ! uri = "<url_of_debian_repository> (e.g.; http://archive.ubuntu.com/ubuntu)"
-                ! suites = ["<suite> (e.g.; jammy)"]
-                ! components = ["<component> (e.g.; main)"]
-                ! arch = ["<architecture> (e.g.; amd64 or arm64)"]
-                ! signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
-                ! <ASCII-armored GPG key>
-                ! -----END PGP PUBLIC KEY BLOCK-----
-                !
-                ! Suggestions:
-                ! - See the buildpack documentation for the proper usage for this configuration at \
-                ! https://github.com/heroku/buildpacks-deb-packages#configuration
-                ! - See the TOML documentation for more details on the TOML array of tables type \
-                ! at https://toml.io/en/v1.0.0
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
-        "#},
-        );
+        assert_error_snapshot(&on_config_error(ConfigError::ParseConfig(
+            "/path/to/project.toml".into(),
+            ParseConfigError::ParseCustomSource(Box::from(
+                ParseCustomSourceError::MissingArchitectureNames(table),
+            )),
+        )));
     }
 
     #[test]
@@ -1728,845 +1225,215 @@ mod tests {
         let mut arch = toml_edit::Array::new();
         arch.push("i386");
         table.insert("arch", toml_edit::Item::Value(toml_edit::Value::from(arch)));
-        test_error_output(
-            "
-                Context
-                -------
-                We read the buildpack configuration from project.toml which must be a valid TOML file.
-                If the file is valid but the value supplied using the configuration for this buildpack
-                contains a custom source that is missing the 'arch' field or the field contains
-                non-string values or unsupported architecture names, it is invalid.
-                We report this to the user and request they check the buildpack documentation for proper
-                usage.
-            ",
-            ConfigError::ParseConfig(
-                "/path/to/project.toml".into(),
-                ParseConfigError::ParseCustomSource(Box::from(ParseCustomSourceError::InvalidArchitectureName(table, UnsupportedArchitectureNameError("i386".into())))),
-            ),
-            &formatdoc! { r#"
-                - Debug Info:
-                  - Invalid architecture name found for the following custom source:
-                    [[com.heroku.buildpacks.deb-packages.sources]]
-                    uri = "http://archive.ubuntu.com/ubuntu"
-                    suites = ["main"]
-                    components = ["multiverse"]
-                    arch = ["i386"]
-                    signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
-
-                    NxRt3Z+7w5HMIN2laKp+ItxloPWGBdcHU4o2ZnWgsVT8Y/a+RED75DDbAQ6lS3fV
-                    sSlmQLExcf75qOPy34XNv3gWP4tbfIXXt8olflF8hwHggmKZzEImnzEozPabDsN7
-                    nkhHZEWhGcPRcuHbFOqcirV1sfsKK1gOsTbxS00iD3OivOFCQqujF196cal/utTd
-                    hVnssTC1arrx273zFepLosPvgrT0TS7tnyXbzuq5mo0zD1fSj4kuSS9V/SSy9fWF
-                    LAtHiNQJkjzGFxu0/9dyQyX6C523uvfdcOzpObTyjBeGKqmEEf0lF5OYLDlkk2Sm
-                    iGa6i2oLaGzGaQZDpdqyQZiYpQEYw9xN+8g=
-                    =J31U
-                    -----END PGP PUBLIC KEY BLOCK-----
-                    """
-
-                    ---
-                    Unsupported architecture name: "i386"
-                    Must be one of:
-                    - "amd64"
-                    - "arm64"
-
-                ! Error parsing `/path/to/project.toml` with invalid custom source
-                !
-                ! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` to \
-                ! complete the build but we found an invalid custom source in the \
-                ! key `[com.heroku.buildpacks.deb-packages]`.
-                !
-                ! Custom sources must be in the following format:
-                !
-                ! [[com.heroku.buildpacks.deb-packages.sources]]
-                ! uri = "<url_of_debian_repository> (e.g.; http://archive.ubuntu.com/ubuntu)"
-                ! suites = ["<suite> (e.g.; jammy)"]
-                ! components = ["<component> (e.g.; main)"]
-                ! arch = ["<architecture> (e.g.; amd64 or arm64)"]
-                ! signed_by = """-----BEGIN PGP PUBLIC KEY BLOCK-----
-                ! <ASCII-armored GPG key>
-                ! -----END PGP PUBLIC KEY BLOCK-----
-                !
-                ! Suggestions:
-                ! - See the buildpack documentation for the proper usage for this configuration at \
-                ! https://github.com/heroku/buildpacks-deb-packages#configuration
-                ! - See the TOML documentation for more details on the TOML array of tables type \
-                ! at https://toml.io/en/v1.0.0
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
-        "#},
-        );
+        assert_error_snapshot(&on_config_error(ConfigError::ParseConfig(
+            "/path/to/project.toml".into(),
+            ParseConfigError::ParseCustomSource(Box::from(
+                ParseCustomSourceError::InvalidArchitectureName(
+                    table,
+                    UnsupportedArchitectureNameError("i386".into()),
+                ),
+            )),
+        )));
     }
 
     #[test]
     fn config_parse_config_error_for_invalid_download_url() {
-        test_error_output(
-            "
-            Context
-            -------
-            We read the buildpack configuration from project.toml which must be a valid TOML file.
-            If the file is valid but the value supplied using the configuration for this buildpack
-            contains a download url that would be invalid according to some validation rules,
-            we report this url to the user and ask them to verify it.
-            ",
-            ConfigError::ParseConfig(
-                "/path/to/project.toml".into(),
-                ParseConfigError::ParseDownloadUrl(Box::from(ParseDownloadUrlError::InvalidUrl {
-                    url: "not a url".into(),
-                    reason: Url::parse("not a url").unwrap_err().to_string(),
-                })),
-            ),
-            indoc! {"
-                ! Error parsing `/path/to/project.toml` with invalid download url
-                !
-                ! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` \
-                to complete the build but we found an invalid download url `not a url` \
-                in the key `[com.heroku.buildpacks.deb-packages]`.
-                !
-                ! Validation error: relative URL without a base
-                !
-                ! Suggestions:
-                ! - Verify the download url is valid.
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
-            "},
-        );
+        assert_error_snapshot(&on_config_error(ConfigError::ParseConfig(
+            "/path/to/project.toml".into(),
+            ParseConfigError::ParseDownloadUrl(Box::from(ParseDownloadUrlError::InvalidUrl {
+                url: "not a url".into(),
+                reason: Url::parse("not a url").unwrap_err().to_string(),
+            })),
+        )));
     }
 
     #[test]
     fn config_parse_config_error_for_invalid_download_url_config_type() {
-        test_error_output(
-            "
-            Context
-            -------
-            We read the buildpack configuration from project.toml which must be a valid TOML file.
-            If the file is valid but the value supplied using the configuration for this buildpack
-            contains a package entry that is neither a string nor inline table value, it is invalid.
-            We report this to the user and request they check the buildpack documentation for proper
-            usage.
-            ",
-            ConfigError::ParseConfig(
-                "/path/to/project.toml".into(),
-                ParseConfigError::ParseDownloadUrl(Box::from(
-                    ParseDownloadUrlError::UnexpectedTomlValue(
-                        toml_edit::value(37).into_value().unwrap(),
-                    ),
-                )),
-            ),
-            indoc! {"
-                - Debug Info:
-                  - Invalid type `integer` with value `37`
-
-                ! Error parsing `/path/to/project.toml` with invalid download url
-                !
-                ! The Heroku .deb Packages buildpack reads configuration from `/path/to/project.toml` \
-                to complete the build but we found an invalid download url in the key \
-                `[com.heroku.buildpacks.deb-packages]`.
-                !
-                ! Download urls must either be the following TOML values:
-                ! - String (e.g.; \"https://example.com/package-1.2.3.deb\")
-                !
-                ! Suggestions:
-                ! - See the buildpack documentation for the proper usage for this configuration at \
-                https://github.com/heroku/buildpacks-deb-packages#configuration
-                ! - See the TOML documentation for more details on the TOML string at https://toml.io/en/v1.0.0
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
-            "},
-        );
+        assert_error_snapshot(&on_config_error(ConfigError::ParseConfig(
+            "/path/to/project.toml".into(),
+            ParseConfigError::ParseDownloadUrl(Box::from(
+                ParseDownloadUrlError::UnexpectedTomlValue(
+                    toml_edit::value(37).into_value().unwrap(),
+                ),
+            )),
+        )));
     }
 
     #[test]
     fn unsupported_distro_error() {
-        test_error_output("
-                Context
-                -------
-                This buildpack only supports specific distributions listed in buildpack.toml.
-                Anything else is unsupported. This error is unlikely to be seen by an end-user but may
-                be helpful for developers hacking on this buildpack. Tools like pack also validate
-                buildpacks against their target distribution metadata to prevent this exact scenario.
-            ",
-                          UnsupportedDistro(UnsupportedDistroError {
-                              name: "Windows".to_string(),
-                              version: "XP".to_string(),
-                              architecture: "x86".to_string(),
-                          }),
-                          indoc! {"
-                ! Unsupported distribution
-                !
-                ! The Heroku .deb Packages buildpack doesn't support the Windows XP (x86) \
-                distribution. See `buildpack.toml` for the configuration of supported distributions.
-                !
-                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
-                a workaround at this time. You can help our understanding by sharing your buildpack log \
-                and a description of the issue at:
-                ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-                !
-                ! If you're able to reproduce the problem with an example application and the `pack` \
-                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
-                adding that information to the discussion will also help. Once we have more information \
-                around the causes of this error we may update this message.
-            "},
-        );
+        assert_error_snapshot(&on_unsupported_distro_error(UnsupportedDistroError {
+            name: "Windows".to_string(),
+            version: "XP".to_string(),
+            architecture: "x86".to_string(),
+        }));
     }
 
     #[test]
     fn create_package_index_error_no_sources() {
-        test_error_output("
-                Context
-                -------
-                This is a developer error. It should never be seen by an end-user but could occur if
-                the registered sources for a distribution were modified or someone forgot to register
-                ones for a specific architecture. Our testing processes should always catch this but,
-                if not, we should direct users to file an issue.
-            ",
-                          CreatePackageIndexError::NoSources,
-                          indoc! {"
-                ! No sources to update
-                !
-                ! The distribution has no sources to update packages from.
-                !
-                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
-                a workaround at this time. You can help our understanding by sharing your buildpack log \
-                and a description of the issue at:
-                ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-                !
-                ! If you're able to reproduce the problem with an example application and the `pack` \
-                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
-                adding that information to the discussion will also help. Once we have more information \
-                around the causes of this error we may update this message.
-            "},
-        );
+        assert_error_snapshot(&on_create_package_index_error(
+            CreatePackageIndexError::NoSources,
+        ));
     }
 
     #[test]
     fn create_package_index_error_task_failed() {
-        test_error_output_with_custom_assertion(
-            "
-                Context
-                -------
-                This is a developer error. It should never be seen by an end-user. Package indexes
-                are updated using async tasks which can fail if the task panics or is cancelled but
-                we don't cancel running tasks and we handle all errors.
-            ",
-            CreatePackageIndexError::TaskFailed(create_join_error()),
-            |actual_text| {
-                assert_contains_match!(
-                    actual_text,
-                    indoc! {"
-                        - Debug Info:
-                          - task \\d+ panicked with message \"uh oh!\"
-
-                        ! Task failure while updating sources
-                        !
-                        ! A background task responsible for updating sources failed to complete.
-                        !
-                        ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
-                        a workaround at this time. You can help our understanding by sharing your buildpack log \
-                        and a description of the issue at:
-                        ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-                        !
-                        ! If you're able to reproduce the problem with an example application and the `pack` \
-                        build tool \\(https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/\\), \
-                        adding that information to the discussion will also help. Once we have more information \
-                        around the causes of this error we may update this message.
-                    "}
-                );
-            },
+        assert_error_snapshot_with_filters(
+            &on_create_package_index_error(
+                CreatePackageIndexError::TaskFailed(create_join_error()),
+            ),
+            vec![("task \\d+", "task <ID>")],
         );
     }
 
     #[test]
     fn create_package_index_error_invalid_layer_name() {
-        test_error_output(
-            "
-                Context
-                -------
-                This is a developer error. It should never be seen by an end-user. The only restrictions
-                on layer naming are that it can't be named 'build', 'launch', or 'cache' and it must be
-                a valid filename. The hexidecimal character set used here should be safe. If a bug is
-                introduced in how this name is generated then we report this and ask the user to file
-                an issue against this buildpack.
-            ",
+        assert_error_snapshot(&on_create_package_index_error(
             CreatePackageIndexError::InvalidLayerName(
                 "http://archive.ubuntu.com/ubuntu/dists/jammy/InRelease".to_string(),
                 LayerNameError::InvalidValue(
                     "623e1a2085e65abc3dc626a97909466ce19efe37f7a6529a842c290fcfc65b3b".to_string(),
                 ),
             ),
-            indoc! {"
-                - Debug Info:
-                  - Invalid Value: 623e1a2085e65abc3dc626a97909466ce19efe37f7a6529a842c290fcfc65b3b
-
-                ! Invalid layer name
-                !
-                ! For caching purposes, a unique layer name is generated for Debian Release files \
-                and Package indices based on their download urls. The generated name for the following \
-                url was invalid:
-                ! - http://archive.ubuntu.com/ubuntu/dists/jammy/InRelease
-                !
-                ! You can find the invalid layer name in the debug information above.
-                !
-                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
-                a workaround at this time. You can help our understanding by sharing your buildpack log \
-                and a description of the issue at:
-                ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-                !
-                ! If you're able to reproduce the problem with an example application and the `pack` \
-                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
-                adding that information to the discussion will also help. Once we have more information \
-                around the causes of this error we may update this message.
-            "},
-        );
+        ));
     }
 
     #[test]
     fn create_package_index_error_get_release_request() {
-        test_error_output(
-            "
-                Context
-                -------
-                Package sources are requested from a Debian repository starting with a download of
-                the repository's release file. Network I/O can fail for any number of reasons but
-                the most likely here is that there is a problem with the upstream repository which
-                does have a status page we can direct the user to.
-            ",
+        assert_error_snapshot(&on_create_package_index_error(
             CreatePackageIndexError::GetReleaseRequest(create_reqwest_middleware_error()),
-            indoc! {"
-                - Debug Info:
-                  - error sending request for url (https://test/error)
-
-                ! Failed to request Release file
-                !
-                ! While updating package sources, a request to download a Release file failed. This error \
-                can occur due to an unstable network connection or an issue with the upstream Debian \
-                package repository.
-                !
-                ! Suggestions:
-                ! - Check the status of https://status.canonical.com/ for any reported issues.
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
-                !
-                ! If the issue persists and you think you found a bug in the buildpack, reproduce the \
-                issue locally with a minimal example. Open an issue in the buildpack's GitHub repository \
-                and include the details here:
-                ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-            "},
-        );
+        ));
     }
 
     #[test]
     fn create_package_index_error_read_get_release_response() {
-        test_error_output(
-            "
-                Context
-                -------
-                Package sources are requested from a Debian repository starting with a download of
-                the repository's release file. This error happens after the request has been initiated
-                and we start reading the response body. Network I/O can fail for any number of reasons but
-                the most likely here is that there is a problem with the upstream repository which
-                does have a status page we can direct the user to.
-            ",
+        assert_error_snapshot(&on_create_package_index_error(
             CreatePackageIndexError::ReadGetReleaseResponse(create_reqwest_error()),
-            indoc! {"
-                - Debug Info:
-                  - error sending request for url (https://test/error)
-
-                ! Failed to download Release file
-                !
-                ! While updating package sources, an error occurred while downloading a Release \
-                file. This error can occur due to an unstable network connection or an issue with the upstream \
-                Debian package repository.
-                !
-                ! Suggestions:
-                ! - Check the status of https://status.canonical.com/ for any reported issues.
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
-                !
-                ! If the issue persists and you think you found a bug in the buildpack, reproduce the \
-                issue locally with a minimal example. Open an issue in the buildpack's GitHub repository \
-                and include the details here:
-                ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-            "},
-        );
+        ));
     }
 
     #[test]
     fn create_package_index_error_create_pgp_certificate() {
-        test_error_output(
-            "
-                Context
-                -------
-                This is a developer error. It should never be seen by an end-user. We validate
-                release files using PGP certificates from the supported distributions and if there
-                is a problem with the certificate file, this error would happen. Our testing processes
-                should always catch this but, if not, we should direct users to file an issue.
-            ",
+        assert_error_snapshot(&on_create_package_index_error(
             CreatePackageIndexError::CreatePgpCertificate(anyhow!(
                 "Additional packets found, is this a keyring?"
             )),
-            indoc! {"
-                - Debug Info:
-                  - Additional packets found, is this a keyring?
-
-                ! Failed to load verifying PGP certificate
-                !
-                ! The PGP certificate used to verify downloaded release files failed to load. This error \
-                indicates there's a problem with the format of the certificate file the \
-                distribution uses.
-                !
-                ! Suggestions:
-                ! - Verify the format of the certificates found in the ./keys directory of this \
-                buildpack's repository. See https://cirw.in/gpg-decoder
-                ! - Extract new certificates by running the ./scripts/extract_keys.sh script found \
-                in this buildpack's repository.
-                !
-                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
-                a workaround at this time. You can help our understanding by sharing your buildpack log \
-                and a description of the issue at:
-                ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-                !
-                ! If you're able to reproduce the problem with an example application and the `pack` \
-                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
-                adding that information to the discussion will also help. Once we have more information \
-                around the causes of this error we may update this message.
-            "},
-        );
+        ));
     }
 
     #[test]
     fn create_package_index_error_create_pgp_verifier() {
-        test_error_output(
-            "
-                Context
-                -------
-                This is a developer error. It should never be seen by an end-user. We validate
-                release files using PGP certificates from the supported distributions and if there
-                is a problem with how the release files are signed, this error would happen. Our
-                testing processes should always catch this but, if not, we should direct users to file
-                an issue.
-            ",
+        assert_error_snapshot(&on_create_package_index_error(
             CreatePackageIndexError::CreatePgpVerifier(anyhow!("Malformed OpenPGP message")),
-            indoc! {"
-                - Debug Info:
-                  - Malformed OpenPGP message
-
-                ! Failed to verify Release file
-                !
-                ! The PGP signature of the downloaded release file failed verification. This error can \
-                occur if the maintainers of the Debian repository changed the process \
-                for signing release files.
-                !
-                ! Suggestions:
-                ! - Verify if the keys changed by running the ./scripts/extract_keys.sh script \
-                found in this buildpack's repository.
-                !
-                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
-                a workaround at this time. You can help our understanding by sharing your buildpack log \
-                and a description of the issue at:
-                ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-                !
-                ! If you're able to reproduce the problem with an example application and the `pack` \
-                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
-                adding that information to the discussion will also help. Once we have more information \
-                around the causes of this error we may update this message.
-            "},
-        );
+        ));
     }
 
     #[test]
     fn create_package_index_error_write_release_layer() {
-        test_error_output(
-            "
-                Context
-                -------
-                We write downloaded release files and other information into the release layer. I/O
-                operations can fail for any number of reasons which we can't anticipate and since this
-                file-system area is managed by the buildpack process there is nothing the user can do
-                here other than report it.
-            ",
+        assert_error_snapshot(&on_create_package_index_error(
             CreatePackageIndexError::WriteReleaseLayer(
                 "/path/to/layer/file".into(),
                 create_io_error("out of memory"),
             ),
-            indoc! {"
-                - Debug Info:
-                  - out of memory
-
-                ! Failed to write Release file to layer
-                !
-                ! An unexpected I/O error occurred while writing release data to `/path/to/layer/file`.
-                !
-                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
-                a workaround at this time. You can help our understanding by sharing your buildpack log \
-                and a description of the issue at:
-                ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-                !
-                ! If you're able to reproduce the problem with an example application and the `pack` \
-                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
-                adding that information to the discussion will also help. Once we have more information \
-                around the causes of this error we may update this message.
-            "},
-        );
+        ));
     }
 
     #[test]
     fn create_package_index_error_read_release_file() {
-        test_error_output(
-            "
-                Context
-                -------
-                We read cached release files and other information from the release layer. I/O
-                operations can fail for any number of reasons which we can't anticipate and since this
-                file-system area is managed by the buildpack process there is nothing the user can do
-                here other than report it.
-            ",
+        assert_error_snapshot(&on_create_package_index_error(
             CreatePackageIndexError::ReadReleaseFile(
                 "/path/to/layer/release-file".into(),
                 create_io_error("not found"),
             ),
-            indoc! {"
-                - Debug Info:
-                  - not found
-
-                ! Failed to read Release file from layer
-                !
-                ! An unexpected I/O error occurred while reading Release data from `/path/to/layer/release-file`.
-                !
-                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
-                a workaround at this time. You can help our understanding by sharing your buildpack log \
-                and a description of the issue at:
-                ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-                !
-                ! If you're able to reproduce the problem with an example application and the `pack` \
-                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
-                adding that information to the discussion will also help. Once we have more information \
-                around the causes of this error we may update this message.
-            "},
-        );
+        ));
     }
 
     #[test]
     fn create_package_index_error_parse_release_file() {
-        test_error_output(
-            "
-                Context
-                -------
-                If the release file cannot be parsed, this is either a developer error or a serious
-                problem with the downloaded release file. Running the build with a clean cache
-                should force the file to be re-downloaded which may correct the issue.
-            ",
+        assert_error_snapshot(&on_create_package_index_error(
             CreatePackageIndexError::ParseReleaseFile(
                 "/path/to/layer/release-file".into(),
                 apt_parser::errors::ParseError.into(),
             ),
-            indoc! {"
-                - Debug Info:
-                  - Failed to parse an APT value
-
-                ! Failed to parse Release file data
-                !
-                ! We couldn't parse the Release file data stored in `/path/to/layer/release-file`. \
-                This error is most likely a buildpack bug. It can also be caused by cached data \
-                that's no longer valid or an issue with the upstream repository.
-                !
-                ! Suggestions:
-                ! - Run the build again with a clean cache.
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
-                !
-                ! If the issue persists and you think you found a bug in the buildpack, reproduce the \
-                issue locally with a minimal example. Open an issue in the buildpack's GitHub repository \
-                and include the details here:
-                ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-            "},
-        );
+        ));
     }
 
     #[test]
     fn create_package_index_error_missing_sha256_release_hashes() {
-        test_error_output(
-            "
-                Context
-                -------
-                If the release file downloaded from the Debian repository is missing the SHA256 release
-                key then that's a serious problem with the repository.
-            ",
+        assert_error_snapshot(&on_create_package_index_error(
             CreatePackageIndexError::MissingSha256ReleaseHashes(RepositoryUri::from(
                 "http://archive.ubuntu.com/ubuntu/dists/jammy/InRelease",
             )),
-            indoc! {"
-                ! Missing SHA256 Release hash
-                !
-                ! The Release file from http://archive.ubuntu.com/ubuntu/dists/jammy/InRelease \
-                is missing the SHA256 key which is required according to the documented Debian repository format. \
-                This error is most likely an issue with the upstream repository. See \
-                https://wiki.debian.org/DebianRepository/Format
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
-                !
-                ! If the issue persists and you think you found a bug in the buildpack, reproduce the \
-                issue locally with a minimal example. Open an issue in the buildpack's GitHub repository \
-                and include the details here:
-                ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-            "},
-        );
+        ));
     }
 
     #[test]
     fn create_package_index_error_missing_package_index_release_hash() {
-        test_error_output(
-            "
-                Context
-                -------
-                If the release file downloaded from the Debian repository is missing the package index
-                entry for a component then there's a serious problem with the repository.
-            ",
+        assert_error_snapshot(&on_create_package_index_error(
             CreatePackageIndexError::MissingPackageIndexReleaseHash(
                 RepositoryUri::from("http://archive.ubuntu.com/ubuntu/dists/jammy/InRelease"),
                 "main/binary-amd64/Packages.gz".to_string(),
             ),
-            indoc! {"
-                ! Missing Package Index
-                !
-                ! The Release file from http://archive.ubuntu.com/ubuntu/dists/jammy/InRelease is \
-                missing an entry for `main/binary-amd64/Packages.gz` within the SHA256 section. This error \
-                is most likely a buildpack bug but can also be an issue with the upstream \
-                repository.
-                !
-                ! Suggestions:
-                ! - Verify if `main/binary-amd64/Packages.gz` is under the SHA256 section of \
-                http://archive.ubuntu.com/ubuntu/dists/jammy/InRelease
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
-                !
-                ! If the issue persists and you think you found a bug in the buildpack, reproduce the \
-                issue locally with a minimal example. Open an issue in the buildpack's GitHub repository \
-                and include the details here:
-                ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-            "},
-        );
+        ));
     }
 
     #[test]
     fn create_package_index_error_get_packages_request() {
-        test_error_output(
-            "
-                Context
-                -------
-                After downloading the release file, the next step for updating sources is to fetch
-                the package indexes. Network I/O can fail for any number of reasons but
-                the most likely here is that there is a problem with the upstream repository which
-                does have a status page we can direct the user to.
-            ",
+        assert_error_snapshot(&on_create_package_index_error(
             CreatePackageIndexError::GetPackagesRequest(create_reqwest_middleware_error()),
-            indoc! {"
-                - Debug Info:
-                  - error sending request for url (https://test/error)
-
-                ! Failed to request Package Index file
-                !
-                ! While updating package sources, a request to download a Package Index file failed. \
-                This error can occur due to an unstable network connection or an issue with the upstream Debian \
-                package repository.
-                !
-                ! Suggestions:
-                ! - Check the status of https://status.canonical.com/ for any reported issues.
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
-                !
-                ! If the issue persists and you think you found a bug in the buildpack, reproduce the \
-                issue locally with a minimal example. Open an issue in the buildpack's GitHub repository \
-                and include the details here:
-                ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-            "},
-        );
+        ));
     }
 
     #[test]
     fn create_package_index_error_write_package_layer() {
-        test_error_output(
-            "
-                Context
-                -------
-                When downloading a package index the response body stream is written directly to the
-                file-system. This error could happen if the file to write to could not be opened.
-            ",
+        assert_error_snapshot(&on_create_package_index_error(
             CreatePackageIndexError::WritePackagesLayer(
                 "/path/to/layer/package".into(),
                 create_io_error("entity already exists"),
             ),
-            indoc! {"
-                - Debug Info:
-                  - entity already exists
-
-                ! Failed to write Package Index file to layer
-                !
-                ! An unexpected I/O error occurred while writing Package Index data to `/path/to/layer/package`.
-                !
-                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
-                a workaround at this time. You can help our understanding by sharing your buildpack log \
-                and a description of the issue at:
-                ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-                !
-                ! If you're able to reproduce the problem with an example application and the `pack` \
-                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
-                adding that information to the discussion will also help. Once we have more information \
-                around the causes of this error we may update this message.
-            "},
-        );
+        ));
     }
 
     #[test]
     fn create_package_index_error_write_package_index_from_response() {
-        test_error_output(
-            "
-                Context
-                -------
-                When downloading a package index the response body stream is written directly to the
-                file-system. File and network I/O can fail for any number of reasons but the most
-                likely here would be a connection interruption.
-            ",
+        assert_error_snapshot(&on_create_package_index_error(
             CreatePackageIndexError::WritePackageIndexFromResponse(
                 "/path/to/layer/package-index".into(),
                 create_io_error("stream closed"),
             ),
-            indoc! {"
-                - Debug Info:
-                  - stream closed
-
-                ! Failed to download Package Index file
-                !
-                ! While updating package sources, an error occurred while downloading a Package Index \
-                file to `/path/to/layer/package-index`. This error can occur due to an unstable network connection \
-                or an issue with the upstream Debian package repository.
-                !
-                ! Suggestions:
-                ! - Check the status of https://status.canonical.com/ for any reported issues.
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
-                !
-                ! If the issue persists and you think you found a bug in the buildpack, reproduce the \
-                issue locally with a minimal example. Open an issue in the buildpack's GitHub repository \
-                and include the details here:
-                ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-            "},
-        );
+        ));
     }
 
     #[test]
     fn create_package_index_error_checksum_failed() {
-        test_error_output(
-            "
-                Context
-                -------
-                All downloaded package indexes are verified according to the checksum given by the
-                owning release file. If these checksums don't match then the download is invalid. When
-                this happens a rebuild typically fixes the issue.
-            ",
+        assert_error_snapshot(&on_create_package_index_error(
             CreatePackageIndexError::ChecksumFailed {
                 url: "http://ports.ubuntu.com/ubuntu-ports/dists/noble/main/binary-arm64/by-hash/SHA256/d41d8cd98f00b204e9800998ecf8427e".to_string(),
                 expected: "d41d8cd98f00b204e9800998ecf8427e".to_string(),
                 actual: "e62ff0123a74adfc6903d59a449cbdb0".to_string(),
             },
-            indoc! {"
-                ! Package Index checksum verification failed
-                !
-                ! While updating package sources, an error occurred while verifying the checksum of \
-                the Package Index at http://ports.ubuntu.com/ubuntu-ports/dists/noble/main/binary-arm64/by-hash/SHA256/d41d8cd98f00b204e9800998ecf8427e. \
-                This error can occur due to an issue with the upstream Debian package repository.
-                !
-                ! Checksum:
-                ! - Expected: `d41d8cd98f00b204e9800998ecf8427e`
-                ! - Actual: `e62ff0123a74adfc6903d59a449cbdb0`
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
-            "},
-        );
+        ));
     }
 
     #[test]
     fn create_package_index_error_cpu_task_failed() {
-        test_error_output(
-            "
-                Context
-                -------
-                This is a developer error. It should never be seen by an end-user. Processing package
-                index files is a CPU-intensive operation and happens in parallel worker tasks for
-                efficiency. This error can happen if a worker task panics and the error isn't handled.
-                Our testing processes should always catch this but, if not, we should direct users to file
-                an issue.
-            ",
+        assert_error_snapshot(&on_create_package_index_error(
             CreatePackageIndexError::CpuTaskFailed(create_recv_error()),
-            indoc! {"
-                - Debug Info:
-                  - channel closed
-
-                ! Task failure while reading Package Index data
-                !
-                ! A background task responsible for reading Package Index data failed to complete.
-                !
-                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
-                a workaround at this time. You can help our understanding by sharing your buildpack log \
-                and a description of the issue at:
-                ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-                !
-                ! If you're able to reproduce the problem with an example application and the `pack` \
-                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
-                adding that information to the discussion will also help. Once we have more information \
-                around the causes of this error we may update this message.
-            "},
-        );
+        ));
     }
 
     #[test]
     fn create_package_index_error_read_packages_file() {
-        test_error_output(
-            "
-                Context
-                -------
-                This is a developer error. It should never be seen by an end-user. We read from
-                a package index file stored in the layer directory managed by the buildpack process.
-                I/O errors can happen for any number of reasons and there's nothing the user can
-                do here.
-            ",
+        assert_error_snapshot(&on_create_package_index_error(
             CreatePackageIndexError::ReadPackagesFile(
                 "/path/to/layer/packages-file".into(),
                 create_io_error("entity not found"),
             ),
-            indoc! {"
-                - Debug Info:
-                  - entity not found
-
-                ! Failed to read Package Index file
-                !
-                ! An unexpected I/O error occurred while reading Package Index data from \
-                `/path/to/layer/packages-file`.
-                !
-                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
-                a workaround at this time. You can help our understanding by sharing your buildpack log \
-                and a description of the issue at:
-                ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-                !
-                ! If you're able to reproduce the problem with an example application and the `pack` \
-                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
-                adding that information to the discussion will also help. Once we have more information \
-                around the causes of this error we may update this message.
-            "},
-        );
+        ));
     }
 
     #[test]
     fn create_package_index_error_parse_packages() {
-        test_error_output(
-            "
-                Context
-                -------
-                We need to parse all packages contained in a package index file. This error could happen
-                if the package index contained bad data which would indicate a problem with the
-                upstream repository but it's more likely to be a bug with the buildpack. Running the
-                build with a fresh cache would force the package index to be re-downloaded which
-                might fix the issue.
-            ",
+        assert_error_snapshot(&on_create_package_index_error(
             CreatePackageIndexError::ParsePackages(
                 "/path/to/layer/packages-file".into(),
                 vec![
@@ -2576,744 +1443,217 @@ mod tests {
                     ParseRepositoryPackageError::MissingSha256("package-c".to_string()),
                 ],
             ),
-            indoc! {"
-                ! Failed to parse Package Index file
-                !
-                ! We can't parse the Package Index file data stored in `/path/to/layer/packages-file`. \
-                This error is most likely a buildpack bug. It can also be caused by \
-                cached data that's no longer valid or an issue with the upstream repository.
-                !
-                ! Parsing errors:
-                ! - There's an entry that's missing the required `Package` key.
-                ! - Package `package-a` is missing the required `Version` key.
-                ! - Package `package-b` is missing the required `Filename` key.
-                ! - Package `package-c` is missing the required `SHA256` key.
-                !
-                ! Suggestions:
-                ! - Run the build again with a clean cache.
-                !
-                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
-                a workaround at this time. You can help our understanding by sharing your buildpack log \
-                and a description of the issue at:
-                ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-                !
-                ! If you're able to reproduce the problem with an example application and the `pack` \
-                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
-                adding that information to the discussion will also help. Once we have more information \
-                around the causes of this error we may update this message.
-            "},
-        );
+        ));
     }
 
     #[test]
     fn determine_packages_to_install_error_read_system_packages() {
-        test_error_output(
-            "
-                Context
-                -------
-                This is a developer error. It should never be seen by an end-user. All system packages
-                are stored in /var/lib/dpkg/status. I/O errors can happen for any number of reasons
-                but the most likely here is that the file doesn't exist for some reason or the file
-                path was accidentally modified. Our testing processes should always catch this but,
-                if not, we should direct users to file an issue.
-            ",
+        assert_error_snapshot(&on_determine_packages_to_install_error(
             DeterminePackagesToInstallError::ReadSystemPackages(
                 "/var/lib/dpkg/status".into(),
                 create_io_error("entity not found"),
             ),
-            indoc! {"
-                - Debug Info:
-                  - entity not found
-
-                ! Failed to read system packages
-                !
-                ! An unexpected I/O error occurred while reading system packages from `/var/lib/dpkg/status`.
-                !
-                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
-                a workaround at this time. You can help our understanding by sharing your buildpack log \
-                and a description of the issue at:
-                ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-                !
-                ! If you're able to reproduce the problem with an example application and the `pack` \
-                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
-                adding that information to the discussion will also help. Once we have more information \
-                around the causes of this error we may update this message.
-            "},
-        );
+        ));
     }
 
     #[test]
     fn determine_packages_to_install_error_parse_system_packages() {
-        test_error_output(
-            "
-                Context
-                -------
-                This is a developer error. It should never be seen by an end-user. All system packages
-                are stored in /var/lib/dpkg/status and it's unlikely for this file to be malformed. More
-                likely is there is a bug with the parsing logic. Our testing processes should always catch
-                this but, if not, we should direct users to file an issue.
-            ",
+        assert_error_snapshot(&on_determine_packages_to_install_error(
             DeterminePackagesToInstallError::ParseSystemPackage(
                 "/var/lib/dpkg/status".into(),
                 "some-package".to_string(),
                 apt_parser::errors::APTError::KVError(apt_parser::errors::KVError),
             ),
-            indoc! {"
-                - Debug Info:
-                  - Failed to parse APT key-value data
-
-                    Package:
-                    some-package
-
-                ! Failed to parse system package
-                !
-                ! An unexpected parsing error occurred while reading system packages from `/var/lib/dpkg/status`.
-                !
-                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
-                a workaround at this time. You can help our understanding by sharing your buildpack log \
-                and a description of the issue at:
-                ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-                !
-                ! If you're able to reproduce the problem with an example application and the `pack` \
-                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
-                adding that information to the discussion will also help. Once we have more information \
-                around the causes of this error we may update this message.
-            "},
-        );
+        ));
     }
 
     #[test]
     fn determine_packages_to_install_error_package_not_found() {
-        test_error_output(
-            "
-                Context
-                -------
-                We're installing a list of packages given by the user in the buildpack configuration.
-                It's possible to provide a valid name of a package that doesn't actually exist in the
-                Debian repositories used by the distribution. If this happens we direct the user to
-                the package search site for Ubuntu to verify the package name.
-            ",
-            DeterminePackagesToInstallError::PackageNotFound("some-package".to_string(), vec!["some-package1".to_string(), "some-package2".to_string()]),
-            indoc! {"
-                ! Package not found
-                !
-                ! We can't find `some-package` in the Package Index. If \
-                this package is listed in the packages to install for this buildpack then the name is most \
-                likely misspelled. Otherwise, it can be an issue with the \
-                upstream Debian package repository.
-                !
-                ! Did you mean?
-                ! - `some-package1`
-                ! - `some-package2`
-                !
-                ! Suggestions:
-                ! - Verify the package name is correct and exists for the target distribution at \
-                https://packages.ubuntu.com/
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
-            "},
-        );
+        assert_error_snapshot(&on_determine_packages_to_install_error(
+            DeterminePackagesToInstallError::PackageNotFound(
+                "some-package".to_string(),
+                vec!["some-package1".to_string(), "some-package2".to_string()],
+            ),
+        ));
     }
 
     #[test]
     fn determine_packages_to_install_error_package_not_found_with_no_suggestions() {
-        test_error_output(
-            "
-                Context
-                -------
-                We're installing a list of packages given by the user in the buildpack configuration.
-                It's possible to provide a valid name of a package that doesn't actually exist in the
-                Debian repositories used by the distribution. If this happens we direct the user to
-                the package search site for Ubuntu to verify the package name.
-            ",
+        assert_error_snapshot(&on_determine_packages_to_install_error(
             DeterminePackagesToInstallError::PackageNotFound("some-package".to_string(), vec![]),
-            indoc! {"
-                ! Package not found
-                !
-                ! We can't find `some-package` in the Package Index. If \
-                this package is listed in the packages to install for this buildpack then the name is most \
-                likely misspelled. Otherwise, it can be an issue with the \
-                upstream Debian package repository.
-                !
-                ! Did you mean?
-                ! - No similarly named packages found
-                !
-                ! Suggestions:
-                ! - Verify the package name is correct and exists for the target distribution at \
-                https://packages.ubuntu.com/
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
-            "},
-        );
+        ));
     }
 
     #[test]
     fn determine_packages_to_install_error_virtual_package_must_be_specified() {
-        test_error_output(
-            "
-                Context
-                -------
-                We're installing a list of packages given by the user in the buildpack configuration.
-                There is a special type of package name in a Debian repository that represents a
-                'virtual package' which may be implemented by one or more actual packages. This error
-                is shown when there is more than one provider because we can't automatically determine
-                which one should be used without the user's input.
-            ",
+        assert_error_snapshot(&on_determine_packages_to_install_error(
             DeterminePackagesToInstallError::VirtualPackageMustBeSpecified(
                 "some-package".to_string(),
                 HashSet::from(["package-b".to_string(), "package-a".to_string()]),
             ),
-            indoc! {"
-                ! Multiple providers were found for the package `some-package`
-                !
-                ! Sometimes there are several packages which offer more-or-less the same functionality. \
-                In this case, Debian repositories define a virtual package and one or more actual packages \
-                provide an implementation for this virtual package. When multiple providers are found for \
-                a requested package, this buildpack can't automatically choose which one is the desired \
-                implementation.
-                !
-                ! Providing packages:
-                ! - package-a
-                ! - package-b
-                !
-                ! Suggestions:
-                ! - Replace the virtual package `some-package` with one of the above providers.
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
-            "},
-        );
+        ));
     }
 
     #[test]
     fn install_packages_error_task_failed() {
-        test_error_output_with_custom_assertion(
-            "
-                Context
-                -------
-                This is a developer error. It should never be seen by an end-user. Package installations
-                are performed using async tasks which can fail if the task panics or is cancelled but
-                we don't cancel running tasks and we handle all errors.
-            ",
-            InstallPackagesError::TaskFailed(create_join_error()),
-            |actual_text| {
-                assert_contains_match!(
-                    actual_text,
-                    indoc! {"
-                    - Debug Info:
-                      - task \\d+ panicked with message \"uh oh!\"
-
-                    ! Task failure while installing packages
-                    !
-                    ! A background task responsible for installing failed to complete.
-                    !
-                    ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
-                    a workaround at this time. You can help our understanding by sharing your buildpack log \
-                    and a description of the issue at:
-                    ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-                    !
-                    ! If you're able to reproduce the problem with an example application and the `pack` \
-                    build tool \\(https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/\\), \
-                    adding that information to the discussion will also help. Once we have more information \
-                    around the causes of this error we may update this message.
-                "}
-                );
-            },
+        assert_error_snapshot_with_filters(
+            &on_install_packages_error(InstallPackagesError::TaskFailed(create_join_error())),
+            vec![("task \\d+", "task <ID>")],
         );
     }
 
     #[test]
     fn install_packages_error_invalid_filename() {
-        test_error_output(
-            "
-                Context
-                -------
-                This is a developer error. It should never be seen by an end-user. Packages
-                specify a Filename field that can be used to form a filename to download the
-                package to. This error can only happen if that Filename field contains a value
-                of '..' which is unlikely since that would cause serious problems for the upstream
-                repository.
-            ",
+        assert_error_snapshot(&on_install_packages_error(
             InstallPackagesError::InvalidFilename("some-package".to_string(), "..".to_string()),
-            indoc! {"
-                ! Could not determine file name for `some-package`
-                !
-                ! The package information for `some-package` contains a Filename field of `..` which \
-                produces an invalid name to use as a download path.
-                !
-                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
-                a workaround at this time. You can help our understanding by sharing your buildpack log \
-                and a description of the issue at:
-                ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-                !
-                ! If you're able to reproduce the problem with an example application and the `pack` \
-                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
-                adding that information to the discussion will also help. Once we have more information \
-                around the causes of this error we may update this message.
-            "},
-        );
+        ));
     }
 
     #[test]
     fn install_packages_error_request_package() {
-        test_error_output(
-            "
-                Context
-                -------
-                Packages are downloaded from a Debian repository. Network I/O can fail for any number
-                of reasons but the most likely here would be a problem with the upstream.
-            ",
+        assert_error_snapshot(&on_install_packages_error(
             InstallPackagesError::RequestPackage(
                 repository_package("some-package"),
                 create_reqwest_middleware_error(),
             ),
-            indoc! {"
-                - Debug Info:
-                  - error sending request for url (https://test/error)
-
-                ! Failed to request package
-                !
-                ! While installing packages, an error occurred while downloading `some-package`. This error \
-                can occur due to an unstable network connection or an issue with the upstream Debian package \
-                repository.
-                !
-                ! Suggestions:
-                ! - Check the status of https://status.canonical.com/ for any reported issues.
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
-                !
-                ! If the issue persists and you think you found a bug in the buildpack, reproduce the \
-                issue locally with a minimal example. Open an issue in the buildpack's GitHub repository \
-                and include the details here:
-                ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-            "},
-        );
+        ));
     }
 
     #[test]
     fn install_packages_error_request_package_url() {
-        test_error_output(
-            "
-                Context
-                -------
-                Packages are downloaded from custom URLs. Network I/O can fail for any number
-                of reasons including DNS issues, connectivity problems, or the remote server being unavailable.
-            ",
+        assert_error_snapshot(&on_install_packages_error(
             InstallPackagesError::RequestPackageUrl(
                 DownloadUrl::from_str("https://example.com/custom-package.deb").unwrap(),
                 create_reqwest_middleware_error(),
             ),
-            indoc! {"
-                - Debug Info:
-                  - error sending request for url (https://test/error)
-
-                ! Failed to request package from download url
-                !
-                ! While installing packages, an error occurred while downloading the package at \
-                https://example.com/custom-package.deb. This error can occur due to an unstable network \
-                connection or an issue with site this package is hosted at.
-                !
-                ! Suggestions:
-                ! - Check if https://example.com/custom-package.deb can be downloaded locally or if there's an error.
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
-                !
-                ! If the issue persists and you think you found a bug in the buildpack, reproduce the \
-                issue locally with a minimal example. Open an issue in the buildpack's GitHub repository \
-                and include the details here:
-                ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-            "},
-        );
+        ));
     }
 
     #[test]
     fn install_packages_error_write_package() {
-        test_error_output(
-            "
-                Context
-                -------
-                Packages downloaded from a Debian repository are written directly to disk. Network I/O
-                can fail for any number of reasons but the most likely here would be a problem with the upstream.
-            ",
+        assert_error_snapshot(&on_install_packages_error(
             InstallPackagesError::WritePackage(
                 repository_package("some-package"),
                 "https://test/error".to_string(),
                 "/path/to/layer/download-file".into(),
                 create_io_error("stream closed"),
             ),
-            indoc! {"
-                - Debug Info:
-                  - stream closed
-
-                ! Failed to download package
-                !
-                ! An unexpected I/O error occured while downloading `some-package` from https://test/error \
-                to `/path/to/layer/download-file`. This error can occur due to an unstable network connection or \
-                an issue with the upstream Debian package repository.
-                !
-                ! Suggestions:
-                ! - Check the status of https://status.canonical.com/ for any reported issues.
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
-                !
-                ! If the issue persists and you think you found a bug in the buildpack, reproduce the \
-                issue locally with a minimal example. Open an issue in the buildpack's GitHub repository \
-                and include the details here:
-                ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-            "},
-        );
+        ));
     }
 
     #[test]
     fn install_packages_error_write_package_url() {
-        test_error_output(
-            "
-                Context
-                -------
-                Packages downloaded from custom URLs are written directly to disk. Network I/O
-                can fail for any number of reasons including connectivity issues, disk space problems,
-                or interrupted connections.
-            ",
+        assert_error_snapshot(&on_install_packages_error(
             InstallPackagesError::WritePackageUrl(
                 DownloadUrl::from_str("https://example.com/custom-package.deb").unwrap(),
                 "/path/to/layer/custom-package.deb".into(),
                 create_io_error("connection reset"),
             ),
-            indoc! {"
-                - Debug Info:
-                  - connection reset
-
-                ! Failed to download package
-                !
-                ! An unexpected I/O error occured while downloading the package at \
-                https://example.com/custom-package.deb to `/path/to/layer/custom-package.deb`. This error \
-                can occur due to an unstable network connection or an issue with the site this packages is \
-                hosted at.
-                !
-                ! Suggestions:
-                ! - Check if https://example.com/custom-package.deb can be downloaded locally or if there's an error.
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
-                !
-                ! If the issue persists and you think you found a bug in the buildpack, reproduce the \
-                issue locally with a minimal example. Open an issue in the buildpack's GitHub repository \
-                and include the details here:
-                ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-            "},
-        );
+        ));
     }
 
     #[test]
     fn install_packages_error_checksum_failed() {
-        test_error_output(
-            "
-                Context
-                -------
-                Packages downloaded from a Debian repository are validated against a checksum given by
-                their owning package index. If this error happens then there was a problem with the
-                download. When this happens, running the build again typically fixes it.
-            ",
+        assert_error_snapshot(&on_install_packages_error(
             InstallPackagesError::ChecksumFailed {
                 url: "http://archive.ubuntu.com/ubuntu/dists/jammy/some-package.tgz".to_string(),
                 expected: "7931f51fd704f93171f36f5f6f1d7b7b".into(),
                 actual: "19a47cdb280539511523382fa1cabbe5".to_string(),
             },
-            indoc! {"
-                ! Package checksum verification failed
-                !
-                ! An error occurred while verifying the checksum of the package at \
-                http://archive.ubuntu.com/ubuntu/dists/jammy/some-package.tgz. This error can occur due to an \
-                issue with the upstream Debian package repository.
-                !
-                ! Checksum:
-                ! - Expected: `7931f51fd704f93171f36f5f6f1d7b7b`
-                ! - Actual: `19a47cdb280539511523382fa1cabbe5`
-                !
-                ! Use the debug information above to troubleshoot and retry your build.
-            "},
-        );
+        ));
     }
 
     #[test]
     fn install_packages_error_open_package_archive() {
-        test_error_output(
-            "
-                Context
-                -------
-                Packages downloaded from a Debian repository are stored as tarballs which need to be
-                opened for extraction. I/O can fail for any number of reasons but since the buildpack
-                process owns this content, there's nothing the user can do here.
-            ",
+        assert_error_snapshot(&on_install_packages_error(
             InstallPackagesError::OpenPackageArchive(
                 "/path/to/layer/archive-file.tgz".into(),
                 create_io_error("permission denied"),
             ),
-            indoc! {"
-                - Debug Info:
-                  - permission denied
-
-                ! Failed to open package archive
-                !
-                ! An unexpected I/O error occurred while trying to open the archive at `/path/to/layer/archive-file.tgz`.
-                !
-                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
-                a workaround at this time. You can help our understanding by sharing your buildpack log \
-                and a description of the issue at:
-                ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-                !
-                ! If you're able to reproduce the problem with an example application and the `pack` \
-                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
-                adding that information to the discussion will also help. Once we have more information \
-                around the causes of this error we may update this message.
-            "},
-        );
+        ));
     }
 
     #[test]
     fn install_packages_error_open_package_archive_entry() {
-        test_error_output(
-            "
-                Context
-                -------
-                Packages downloaded from a Debian repository are stored as tarballs which stores file
-                information in individual file entries which need to be read for extraction. I/O
-                can fail for any number of reasons but since the buildpack process owns this content,
-                there's nothing the user can do here.
-            ",
+        assert_error_snapshot(&on_install_packages_error(
             InstallPackagesError::OpenPackageArchiveEntry(
                 "/path/to/layer/archive-file.tgz".into(),
                 create_io_error("invalid header entry"),
             ),
-            indoc! {"
-                - Debug Info:
-                  - invalid header entry
-
-                ! Failed to read package archive entry
-                !
-                ! An unexpected I/O error occurred while trying to read the entries of the archive at \
-                `/path/to/layer/archive-file.tgz`.
-                !
-                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
-                a workaround at this time. You can help our understanding by sharing your buildpack log \
-                and a description of the issue at:
-                ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-                !
-                ! If you're able to reproduce the problem with an example application and the `pack` \
-                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
-                adding that information to the discussion will also help. Once we have more information \
-                around the causes of this error we may update this message.
-            "},
-        );
+        ));
     }
 
     #[test]
     fn install_packages_error_unpack_tarball() {
-        test_error_output(
-            "
-                Context
-                -------
-                Packages downloaded from a Debian repository are stored as tarballs which need to be
-                extracted. This is done by iterating through each archive entry and writing it's
-                content out as a file to the file-system. I/O can fail for any number of reasons but
-                since the buildpack process owns this content, there's nothing the user can do here.
-            ",
+        assert_error_snapshot(&on_install_packages_error(
             InstallPackagesError::UnpackTarball(
                 "/path/to/layer/archive-file.tgz".into(),
                 create_io_error("directory not empty"),
             ),
-            indoc! {"
-                - Debug Info:
-                  - directory not empty
-
-                ! Failed to unpack package archive
-                !
-                ! An unexpected I/O error occurred while trying to unpack the archive at `/path/to/layer/archive-file.tgz`.
-                !
-                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
-                a workaround at this time. You can help our understanding by sharing your buildpack log \
-                and a description of the issue at:
-                ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-                !
-                ! If you're able to reproduce the problem with an example application and the `pack` \
-                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
-                adding that information to the discussion will also help. Once we have more information \
-                around the causes of this error we may update this message.
-            "},
-        );
+        ));
     }
 
     #[test]
     fn install_packages_error_unsupported_compression() {
-        test_error_output(
-            "
-                Context
-                -------
-                This is a developer error. It should not be seen by an end-user. Packages from a Debian
-                repository can be stored using several different compression formats. Should we encounter
-                an unexpected one that we aren't handling then this is a buildpack bug.
-            ",
+        assert_error_snapshot(&on_install_packages_error(
             InstallPackagesError::UnsupportedCompression(
                 "/path/to/layer/archive-file.tgz".into(),
                 "lz".to_string(),
             ),
-            indoc! {"
-                ! Unsupported compression format for package archive
-                !
-                ! An unexpected compression format (`lz`) was used for the package archive at \
-                `/path/to/layer/archive-file.tgz`.
-                !
-                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
-                a workaround at this time. You can help our understanding by sharing your buildpack log \
-                and a description of the issue at:
-                ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-                !
-                ! If you're able to reproduce the problem with an example application and the `pack` \
-                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
-                adding that information to the discussion will also help. Once we have more information \
-                around the causes of this error we may update this message.
-            "},
-        );
+        ));
     }
 
     #[test]
     fn install_packages_error_read_package_config() {
-        test_error_output(
-            "
-                Context
-                -------
-                After a package is extracted, we need to update any hardcoded references to it's standard
-                install location that might be referenced in any package-config (*.pc) files from the
-                package to reflect the install location within the layer directory by reading these files.
-                I/O can fail for any number of reasons but since the buildpack process owns this content,
-                there's nothing  the user can do here.
-            ",
+        assert_error_snapshot(&on_install_packages_error(
             InstallPackagesError::ReadPackageConfig(
                 "/path/to/layer/pkgconfig/somepackage.pc".into(),
                 create_io_error("invalid filename"),
             ),
-            indoc! {"
-                - Debug Info:
-                  - invalid filename
-
-                ! Failed to read package config file
-                !
-                ! An unexpected I/O error occurred while reading the package config file at \
-                `/path/to/layer/pkgconfig/somepackage.pc`.
-                !
-                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
-                a workaround at this time. You can help our understanding by sharing your buildpack log \
-                and a description of the issue at:
-                ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-                !
-                ! If you're able to reproduce the problem with an example application and the `pack` \
-                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
-                adding that information to the discussion will also help. Once we have more information \
-                around the causes of this error we may update this message.
-            "},
-        );
+        ));
     }
 
     #[test]
     fn install_packages_error_write_package_config() {
-        test_error_output(
-            "
-                Context
-                -------
-                After a package is extracted, we need to update any hardcoded references to it's standard
-                install location that might be referenced in any package-config (*.pc) files from the
-                package to reflect the install location within the layer directory by writing these files.
-                I/O can fail for any number of reasons but since the buildpack process owns this content,
-                there's nothing  the user can do here.
-            ",
+        assert_error_snapshot(&on_install_packages_error(
             InstallPackagesError::WritePackageConfig(
                 "/path/to/layer/pkgconfig/somepackage.pc".into(),
                 create_io_error("operation interrupted"),
             ),
-            indoc! {"
-                - Debug Info:
-                  - operation interrupted
-
-                ! Failed to write package config file
-                !
-                ! An unexpected I/O error occurred while writing the package config file to \
-                `/path/to/layer/pkgconfig/somepackage.pc`.
-                !
-                ! The causes for this error are unknown. We do not have suggestions for diagnosis or \
-                a workaround at this time. You can help our understanding by sharing your buildpack log \
-                and a description of the issue at:
-                ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-                !
-                ! If you're able to reproduce the problem with an example application and the `pack` \
-                build tool (https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/), \
-                adding that information to the discussion will also help. Once we have more information \
-                around the causes of this error we may update this message.
-            "},
-        );
+        ));
     }
 
     #[test]
     fn framework_error() {
-        test_error_output(
-            "
-                Context
-                -------
-                This message is for any framework errors caused by libcnb.rs and should be consistent
-                with how our other buildpacks report framework errors.
-            ",
-            Error::CannotWriteBuildSbom(create_io_error("operation interrupted")),
-            indoc! {"
-                - Debug Info:
-                  - Couldn't write build SBOM files: operation interrupted
-
-                ! Heroku Deb Packages Buildpack internal error
-                !
-                ! The framework used by this buildpack encountered an unexpected error.
-                !
-                ! If you can’t deploy to Heroku due to this issue, check the official Heroku Status \
-                page at status.heroku.com for any ongoing incidents. After all incidents resolve, retry \
-                your build.
-                !
-                ! Use the debug information above to troubleshoot and retry your build. If you think you \
-                found a bug in the buildpack, reproduce the issue locally with a minimal example and file \
-                an issue here:
-                ! https://github.com/heroku/buildpacks-deb-packages/issues/new
-            "},
-        );
+        let error = Error::CannotWriteBuildSbom(create_io_error("operation interrupted"));
+        assert_error_snapshot(&on_framework_error(&error));
     }
 
-    fn test_error_output(
-        context: &str,
-        error: impl Into<Error<DebianPackagesBuildpackError>>,
-        expected_text: &str,
-    ) {
-        test_error_output_with_custom_assertion(context, error, |actual_text| {
-            assert_eq!(normalize_text(&actual_text), normalize_text(expected_text));
+    fn assert_error_snapshot(error: &ErrorMessage) {
+        assert_error_snapshot_with_filters(error, vec![]);
+    }
+
+    fn assert_error_snapshot_with_filters(error: &ErrorMessage, filters: Vec<(&str, &str)>) {
+        let output = strip_ansi(error.to_string());
+        let test_name = std::thread::current()
+            .name()
+            .expect("Test name should be available as the current thread name")
+            .replace("::", "_")
+            .replace("_tests", "");
+        let snapshot_path = std::env::var("CARGO_MANIFEST_DIR")
+            .map(PathBuf::from)
+            .expect(
+                "The CARGO_MANIFEST_DIR should be automatically set by Cargo when running tests",
+            )
+            .join("src/__snapshots");
+        with_settings!({
+            prepend_module_to_snapshot => false,
+            omit_expression => true,
+            snapshot_path => snapshot_path,
+            filters => filters,
+        }, {
+            assert_snapshot!(test_name, output);
         });
-    }
-
-    fn test_error_output_with_custom_assertion(
-        // this is present to enforce adding contextual information for the error to be used in reviews
-        _context: &str,
-        error: impl Into<Error<DebianPackagesBuildpackError>>,
-        assert_fn: impl FnOnce(String),
-    ) {
-        let output = bullet_stream::global::with_locked_writer(Vec::new(), || {
-            on_error(error.into());
-        });
-
-        let actual_text = strip_ansi(String::from_utf8_lossy(&output));
-        assert_fn(actual_text);
-    }
-
-    fn normalize_text(input: impl AsRef<str>) -> String {
-        // this transformation helps to reduce some whitespace noise seen when doing output comparisons
-        input
-            .as_ref()
-            .lines()
-            .map(str::trim_end)
-            .collect::<Vec<_>>()
-            .join("\n")
-            .trim()
-            .to_string()
     }
 
     fn create_custom_source_table() -> Table {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,7 +8,8 @@ use crate::errors::ErrorType::{Framework, Internal, UserFacing};
 use crate::install_packages::InstallPackagesError;
 use crate::{DebianPackagesBuildpackError, DetectError};
 use bon::builder;
-use bullet_stream::{global::print, style};
+use bullet_stream::{Print, global::print, style};
+use std::fmt;
 use indoc::{formatdoc, indoc};
 use libcnb::Error;
 use std::collections::BTreeSet;
@@ -1011,6 +1012,20 @@ fn get_package_search_url() -> String {
 struct ErrorMessage {
     debug_info: Option<String>,
     message: String,
+}
+
+impl fmt::Display for ErrorMessage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut log = Print::new(vec![]).without_header();
+        if let Some(debug_info) = &self.debug_info {
+            log = log
+                .bullet(style::important("Debug Info:"))
+                .sub_bullet(debug_info)
+                .done();
+        }
+        let output = log.error(&self.message);
+        write!(f, "{}", String::from_utf8_lossy(&output))
+    }
 }
 
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
## Summary
- Add `insta` dev-dependency with `filters` feature for snapshot testing
- Add `Display` impl for `ErrorMessage` to enable string-based assertions without the global bullet_stream writer
- Convert all 56 error tests from inline string assertions to insta snapshot testing
- Net reduction of ~636 lines while improving test maintainability

## Test plan
- [x] All 56 error snapshot tests pass (`cargo test errors`)
- [x] `cargo clippy --all-targets --locked -- --deny warnings` passes
- [x] `cargo fmt` produces no changes