### PR TITLE
Use FuturesOrdered for deterministic source ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- When the same package version exists in multiple repositories, the package from the first-declared source is now consistently preferred. ([#185](https://github.com/heroku/buildpacks-deb-packages/pull/185))
+
 ## [1.0.0] - 2026-04-03
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ bullet_stream = "0.11"
 const_format = "0.2"
 debversion = "0.5"
 edit-distance = "2"
-futures = { version = "0.3", default-features = false, features = ["io-compat"] }
+futures = { version = "0.3", default-features = false, features = ["alloc", "io-compat"] }
 hex = "0.4"
 indexmap = "2"
 indoc = "2"

--- a/src/create_package_index.rs
+++ b/src/create_package_index.rs
@@ -9,8 +9,10 @@ use apt_parser::Release;
 use apt_parser::errors::APTError;
 use async_compression::tokio::bufread::GzipDecoder;
 use bullet_stream::{global::print, style};
+use futures::StreamExt;
 use futures::TryStreamExt;
 use futures::io::AllowStdIo;
+use futures::stream::FuturesOrdered;
 use libcnb::build::BuildContext;
 use libcnb::data::layer::{LayerName, LayerNameError};
 use libcnb::layer::{
@@ -37,7 +39,7 @@ use tokio::io::{
 };
 use tokio::sync::oneshot::channel;
 use tokio::sync::oneshot::error::RecvError;
-use tokio::task::{JoinError, JoinSet};
+use tokio::task::JoinError;
 use tokio_util::compat::FuturesAsyncReadCompatExt;
 use tokio_util::io::InspectReader;
 use tracing::{Instrument, info, instrument};
@@ -134,11 +136,11 @@ async fn update_sources(
         Err(CreatePackageIndexError::NoSources)?;
     }
 
-    let mut update_source_handles = JoinSet::new();
-
-    for source in sources {
-        for suite in &source.suites {
-            update_source_handles.spawn(
+    let mut tasks: FuturesOrdered<_> = sources
+        .iter()
+        .flat_map(|source| source.suites.iter().map(move |suite| (source, suite)))
+        .map(|(source, suite)| {
+            tokio::spawn(
                 update_source(
                     context.clone(),
                     client.clone(),
@@ -149,15 +151,13 @@ async fn update_sources(
                     source.signed_by.clone(),
                 )
                 .in_current_span(),
-            );
-        }
-    }
+            )
+        })
+        .collect();
 
     let mut updated_sources = vec![];
-    while let Some(update_source_handle) = update_source_handles.join_next().await {
-        let updated_source =
-            update_source_handle.map_err(CreatePackageIndexError::TaskFailed)??;
-        updated_sources.push(updated_source);
+    while let Some(result) = tasks.next().await {
+        updated_sources.push(result.map_err(CreatePackageIndexError::TaskFailed)??);
     }
 
     Ok(updated_sources)
@@ -199,7 +199,8 @@ async fn update_source(
             })
         })?;
 
-    let mut get_package_list_handles = JoinSet::new();
+    let acquire_by_hash = release.acquire_by_hash.unwrap_or_default();
+    let mut get_package_list_tasks = FuturesOrdered::new();
 
     for component in components {
         let package_index = format!("{component}/binary-{arch}/Packages.gz");
@@ -216,25 +217,24 @@ async fn update_source(
                 package_index,
             ))?;
 
-        get_package_list_handles.spawn(
+        get_package_list_tasks.push_back(tokio::spawn(
             get_package_list(
                 context.clone(),
                 client.clone(),
                 repository_uri.clone(),
-                release.acquire_by_hash.unwrap_or_default(),
+                acquire_by_hash,
                 suite.clone(),
                 component.clone(),
                 arch.clone(),
                 package_index_release_hash.hash.clone(),
             )
             .in_current_span(),
-        );
+        ));
     }
 
     let mut updated_package_indexes = vec![];
-    while let Some(get_package_list_handle) = get_package_list_handles.join_next().await {
-        updated_package_indexes
-            .push(get_package_list_handle.map_err(CreatePackageIndexError::TaskFailed)??);
+    while let Some(result) = get_package_list_tasks.next().await {
+        updated_package_indexes.push(result.map_err(CreatePackageIndexError::TaskFailed)??);
     }
 
     Ok(UpdatedSource {
@@ -511,14 +511,14 @@ async fn get_package_list(
 async fn build_package_index(
     updated_sources: Vec<UpdatedPackageIndex>,
 ) -> BuildpackResult<PackageIndex> {
-    let mut get_packages_handles = JoinSet::new();
-    for update_source in updated_sources {
-        get_packages_handles.spawn(read_packages(update_source).in_current_span());
-    }
+    let mut tasks: FuturesOrdered<_> = updated_sources
+        .into_iter()
+        .map(|source| tokio::spawn(read_packages(source).in_current_span()))
+        .collect();
 
     let mut package_index = PackageIndex::default();
-    while let Some(get_package_handle) = get_packages_handles.join_next().await {
-        let packages = get_package_handle.map_err(CreatePackageIndexError::TaskFailed)??;
+    while let Some(result) = tasks.next().await {
+        let packages = result.map_err(CreatePackageIndexError::TaskFailed)??;
         for package in packages {
             package_index.add_package(package);
         }


### PR DESCRIPTION
When the same package version exists in multiple declared sources, the first-declared source should win. Currently `JoinSet` is used to run source-fetching tasks concurrently, but `JoinSet::join_next()` returns results in completion order, not insertion order. This means the "winner" for equal versions is nondeterministic.

This replaces `JoinSet` with `FuturesOrdered` from the `futures` crate (already a dependency) in three functions: `update_sources`, `update_source`, and `build_package_index`. `FuturesOrdered` executes futures concurrently but yields results in the order they were pushed, making the ordering guarantee part of the type contract rather than runtime bookkeeping.

### Comparison with #182

PR #182 solves the same problem by tagging each spawned task with its original index, collecting `(index, result)` tuples, and sorting by index after draining the `JoinSet`. That approach works but has drawbacks:

- The ordering invariant is maintained by runtime code (enumerate + sort) that the compiler cannot verify. Accidentally removing the sort or enumerate silently reintroduces the bug.
- It adds ~75 lines of index-threading boilerplate across three functions, including extra variable clones and `async move` wrappers.
- `JoinSet` advertises itself as unordered — using it and then re-sorting the results fights the type.

`FuturesOrdered` encodes the ordering guarantee in the type itself. Swapping it for `FuturesUnordered` or `JoinSet` would be a visible, reviewable change at the declaration site. The resulting diff is a net deletion of code.

Fixes #79