### PR TITLE
Update rustls-webpki to 0.103.12 to fix security alerts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2804,9 +2804,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
- Updates `rustls-webpki` from 0.103.10 to 0.103.12 via `cargo update`
- Resolves Dependabot alert #22 (URI name constraints incorrectly accepted) and #23 (wildcard DNS name constraints incorrectly accepted)
- Both alerts are low severity — exploitable only after signature verification with a misissued certificate

W-22139375