### PR TITLE
Update rand to 0.9.3 to fix Dependabot security alert #21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2115,7 +2115,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.3",
  "thiserror 2.0.18",
 ]
 
@@ -2373,7 +2373,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bitflags 2.11.0",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -2436,9 +2436,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2661,7 +2661,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a4bd6027df676bcb752d3724db0ea3c0c5fc1dd0376fec51ac7dcaf9cc69be"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.3",
 ]
 
 [[package]]
@@ -2933,7 +2933,7 @@ dependencies = [
  "p256",
  "p384",
  "p521",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_core 0.6.4",
  "regex",
  "regex-syntax",


### PR DESCRIPTION
## Summary
- Updates `rand` from 0.9.2 to 0.9.3 to resolve Dependabot alert #21
- Fixes GHSA-cq8v-f236-94qc: low-severity soundness issue with aliased mutable references in `ThreadRng` reseeding when a custom logger accesses `rand::rng()`
- Lockfile-only change — no code modifications

W-22143285