### PR TITLE
Update default builder to heroku/builder:26

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This buildpack is compatible with the following environments:
 To include this buildpack in your application:
 
 ```shell
-pack build my-app --builder heroku/builder:24 --buildpack heroku/deb-packages
+pack build my-app --builder heroku/builder:26 --buildpack heroku/deb-packages
 ```
 
 And then run the image:

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -835,7 +835,7 @@ fn custom_deb_url_for_jammy_distro() {
     });
 }
 
-const DEFAULT_BUILDER: &str = "heroku/builder:24";
+const DEFAULT_BUILDER: &str = "heroku/builder:26";
 
 fn get_integration_test_builder() -> String {
     std::env::var("INTEGRATION_TEST_CNB_BUILDER").unwrap_or(DEFAULT_BUILDER.to_string())


### PR DESCRIPTION
Updates the README usage example and the integration test default
builder to heroku/builder:26.

GUS-W-22580946.