### PR TITLE
Fix Clippy format-arg lints

### DIFF
--- a/src/config/download_url.rs
+++ b/src/config/download_url.rs
@@ -12,7 +12,7 @@ impl DownloadUrl {
             .path_segments()
             .and_then(|mut paths| paths.next_back())
             .and_then(|path| path.strip_suffix(".deb"))
-            .and_then(|path| if path.is_empty() { None } else { Some(path) })
+            .filter(|&path| !path.is_empty())
     }
 }
 

--- a/src/create_package_index.rs
+++ b/src/create_package_index.rs
@@ -261,7 +261,7 @@ async fn get_release(
 ) -> BuildpackResult<UpdatedReleaseFile> {
     info!({ RELEASE_URI } = %remove_url_credentials(&uri), { RELEASE_SUITE } = %suite, "release info");
 
-    let release_file_url = format!("{}/dists/{suite}/InRelease", &uri);
+    let release_file_url = format!("{uri}/dists/{suite}/InRelease");
 
     let response = client
         .get(&release_file_url)
@@ -389,15 +389,9 @@ async fn get_package_list(
     );
 
     let package_index_url = if acquire_by_hash {
-        format!(
-            "{}/dists/{suite}/{component}/binary-{arch}/by-hash/SHA256/{}",
-            &repository_uri, hash
-        )
+        format!("{repository_uri}/dists/{suite}/{component}/binary-{arch}/by-hash/SHA256/{hash}")
     } else {
-        format!(
-            "{}/dists/{suite}/{component}/binary-{arch}/Packages.gz",
-            &repository_uri
-        )
+        format!("{repository_uri}/dists/{suite}/{component}/binary-{arch}/Packages.gz")
     };
 
     // it would be nice to use the url as the layer name but urls don't make for good file names

--- a/src/debian/package_name.rs
+++ b/src/debian/package_name.rs
@@ -38,7 +38,7 @@ impl FromStr for PackageName {
 
 impl Display for PackageName {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", &self.0)
+        write!(f, "{}", self.0)
     }
 }
 

--- a/src/determine_packages_to_install.rs
+++ b/src/determine_packages_to_install.rs
@@ -389,8 +389,8 @@ impl Display for PackageNotification {
                     package = style::value(&installed_package.name),
                     name_with_version = style::value(format!(
                         "{name}@{version}",
-                        name = &installed_package.name,
-                        version = &installed_package.version
+                        name = installed_package.name,
+                        version = installed_package.version
                     )),
                     installed_by = style::value(installed_by),
                 )
@@ -405,8 +405,8 @@ impl Display for PackageNotification {
                     package = style::value(requested_package),
                     name_with_version = style::value(format!(
                         "{name}@{version}",
-                        name = &implementor.name,
-                        version = &implementor.version
+                        name = implementor.name,
+                        version = implementor.version
                     )),
                 )
             }

--- a/src/install_packages.rs
+++ b/src/install_packages.rs
@@ -554,7 +554,7 @@ async fn rewrite_package_config(package_config: &Path, install_path: &Path) -> B
 fn build_download_url(repository_package: &RepositoryPackage) -> String {
     format!(
         "{}/{}",
-        &repository_package.repository_uri, &repository_package.filename
+        repository_package.repository_uri, repository_package.filename
     )
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,10 +156,10 @@ impl Buildpack for DebianPackagesBuildpack {
         );
 
         print::bullet("Distribution Info");
-        print::sub_bullet(format!("Name: {}", &distro.name));
-        print::sub_bullet(format!("Version: {}", &distro.version));
-        print::sub_bullet(format!("Codename: {}", &distro.codename));
-        print::sub_bullet(format!("Architecture: {}", &distro.architecture));
+        print::sub_bullet(format!("Name: {}", distro.name));
+        print::sub_bullet(format!("Version: {}", distro.version));
+        print::sub_bullet(format!("Codename: {}", distro.codename));
+        print::sub_bullet(format!("Architecture: {}", distro.architecture));
 
         let package_index =
             runtime.block_on(create_package_index(&context, &client, &source_list))?;


### PR DESCRIPTION
Inline format arguments and drop redundant borrows in `format!`/`write!` calls, resolving `uninlined_format_args` and `useless_borrows_in_formatting` warnings reported by the beta Rust toolchain.

Applied via `cargo clippy --fix`. Surfaced while reviewing July's Dependabot PRs.

GUS-W-23303893.