### PR TITLE
Work around Dependabot grouping bug preventing libcnb updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,11 +11,18 @@ updates:
     groups:
       libcnb:
         patterns:
-          - "libcnb*"
+          - "libcnb"
+          - "libcnb-*"
+          - "libherokubuildpack"
       rust-dependencies:
         update-types:
           - "minor"
           - "patch"
+        # Work around: https://github.com/dependabot/dependabot-core/issues/11093
+        exclude-patterns:
+          - "libcnb"
+          - "libcnb-*"
+          - "libherokubuildpack"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc", "io-
 hex = "0.4"
 indexmap = "2"
 indoc = "2"
-libcnb = { version = "0.30", features = ["trace"] }
+libcnb = { version = "=0.30.4", features = ["trace"] }
 rayon = "1"
 reqwest = { version = "0.13", default-features = false, features = ["stream", "rustls-no-provider"] }
 reqwest-middleware = "0.5"
@@ -36,7 +36,7 @@ tracing = "0.1"
 walkdir = "2"
 
 [dev-dependencies]
-libcnb-test = "0.30"
+libcnb-test = "=0.30.4"
 regex = "1"
 tempfile = "3"
 


### PR DESCRIPTION
The Dependabot grouping docs state that when multiple groups are specified, the first group defined wins:
https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups--

However, in practice this is broken and PRs are compared against all groups, and so can end up being placed in a later group - even one whose settings doesn't allow the PR to be opened during a later phase. This results in no PRs being opened for major libcnb version updates, since the PRs are misrouted to the main `rust-dependencies` group, but later filtered out by its `update-types: ["minor", "patch"]` rule.

See:
https://github.com/dependabot/dependabot-core/issues/11093

To work around this, we have to make the groups non-overlapping, by adding an explicit `exclude-patterns` to the other group.

See also: https://github.com/heroku/buildpacks-nodejs/pull/1408

The libcnb version has also been pinned to an exact version using the `=` syntax, since the crate has a large impact on the behaviour of the buildpack, so we want to control its version more carefully. (We used to pin to an exact version in many CNBs in the past, but removed the pin as part of trying to work out why Dependabot wasn't updating.)

GUS-W-23329202.
